### PR TITLE
Add tolerance for plural/singular collections.

### DIFF
--- a/lib/decent_exposure/default_exposure.rb
+++ b/lib/decent_exposure/default_exposure.rb
@@ -5,7 +5,7 @@ module DecentExposure
       klass.superclass_delegating_accessor(:_default_exposure)
       klass.default_exposure do |name|
         collection = name.to_s.pluralize
-        if respond_to?(collection) && send(collection).respond_to?(:scoped)
+        if respond_to?(collection) && collection != name.to_s && send(collection).respond_to?(:scoped)
           proxy = send(collection)
         else
           proxy = name.to_s.classify.constantize

--- a/spec/lib/rails_integration_spec.rb
+++ b/spec/lib/rails_integration_spec.rb
@@ -9,6 +9,12 @@ class Resource
   def initialize(*args); end
 end
 
+class Equipment
+  def self.scoped(opts); self; end
+  def self.find(*args); end
+  def initialize(*args); end
+end
+
 describe "Rails' integration:", DecentExposure do
   let(:controller) { Class.new(ActionController::Base) }
   let(:instance) { controller.new }
@@ -125,6 +131,25 @@ describe "Rails' integration:", DecentExposure do
         Resource.expects(:new).with({:name => 'bob'})
         instance.resource
       end
+    end
+  end
+end
+describe "Rails' integration:", DecentExposure do
+  let(:controller) { Class.new(ActionController::Base) }
+  let(:instance) { controller.new }
+  let(:request) { mock(:get? => true) }
+  let(:params) { HashWithIndifferentAccess.new(:resource_id => 42) }
+
+  before do
+    controller.expose(:equipment)
+    instance.stubs(:request).returns(request)
+    instance.stubs(:params).returns(params)
+  end
+  context 'when collection name is same as resource name' do
+    it 'does not create a collection method' do
+      instance.equipment
+      instance.methods.should include(:equipment)
+      instance.methods.should_not include(:equipments)
     end
   end
 end


### PR DESCRIPTION
Hi Stephen and l4rk (sorry, don't know your name),
Here's a patch that adds tolerance for the problem of entering an infinite loop when a resource has the same singular and plural names. Hope this helps!

Bernie from Tally

P.S. In order to successfully run the original specs I had to change the method names from symbols back to strings (decent_exposure_spec.rb#18 and rails_integration_spec.rb#71). Not sure if that changes anything for you.
