### PR TITLE
Two exposures

### DIFF
--- a/lib/decent_exposure/default_exposure.rb
+++ b/lib/decent_exposure/default_exposure.rb
@@ -4,39 +4,21 @@ module DecentExposure
       klass.extend(DecentExposure)
       klass.superclass_delegating_accessor(:_default_exposure)
       klass.default_exposure do |name|
-        self._resource_name = name.to_s
+        collection = name.to_s.pluralize
+        if respond_to?(collection) && send(collection).respond_to?(:scoped)
+          proxy = send(collection_name)
+        else
+          proxy = name.to_s.classify.constantize
+        end
+
         if id = params["#{name}_id"] || params[:id]
-          _proxy.find(id).tap do |r|
+          proxy.find(id).tap do |r|
             r.attributes = params[name] unless request.get?
           end
         else
-          _proxy.new(params[name])
+          proxy.new(params[name])
         end
       end
-    end
-
-    private
-    attr_accessor :_resource_name
-
-    def _resource_class
-      _resource_name.classify.constantize
-    end
-
-    def _collection_name
-      _resource_name.pluralize
-    end
-
-    def _proxy
-      _collection.respond_to?(:scoped) ? _collection : _resource_class
-    end
-
-    def _collection
-      unless self.class.method_defined?(_collection_name)
-        self.class.expose(_collection_name) do
-          _collection_name.classify.constantize.scoped({})
-        end
-      end
-      send(_collection_name)
     end
   end
 end

--- a/spec/lib/rails_integration_spec.rb
+++ b/spec/lib/rails_integration_spec.rb
@@ -65,9 +65,9 @@ describe "Rails' integration:", DecentExposure do
     end
 
     context 'when no collection method exists' do
-      it 'creates a collection method to scope from' do
+      it 'operates directly on the class' do
+        Resource.should_receive(:find)
         instance.resource
-        instance.methods.should include(:resources)
       end
     end
 


### PR DESCRIPTION
This seems to fix the weird interactions between two default exposures on a single controller. It also eliminates the behavior of having the resource _accessor_ define a collection accessor as a side effect, which is a little nonsensical, in my book.

I spent about 20 minutes trying to get the test suite to reproduce the weirdness before giving up.
