### PR TITLE
Allows decent_exposure to be used in Cells

### DIFF
--- a/lib/decent_exposure.rb
+++ b/lib/decent_exposure.rb
@@ -27,6 +27,6 @@ module DecentExposure
       end
     end
     helper_method name
-    hide_action name
+    hide_action name if self.ancestors.include?(ActionController::Base)
   end
 end


### PR DESCRIPTION
I wanted to use decent_exposure with Cells(https://github.com/apotonick/cells). But Cell::Rails doesn't inherits from ActionController::Base and doesn't have method hide_action. So I had to change decent_exposure a little to make it check for self ancestors before hide_action:
    hide_action name if self.ancestors.include?(ActionController::Base)
That allows DecentExposure::DefaultExposure to be included in Cell::Rails:
    Cell::Rails.send(:include, DecentExposure::DefaultExposure)

```
class EnvironmentCell < Cell::Rails
  expose(:ruby_version) { RUBY_VERSION }
  expose(:rails_version) { ::Rails::VERSION::STRING }

  def display
    render
  end
end
```

I'm not an ruby&rails expert, so I still not sure this is right thing to do...
