### PR TITLE
Consider adding an expose! method

### DIFF
--- a/lib/decent_exposure.rb
+++ b/lib/decent_exposure.rb
@@ -29,4 +29,9 @@ module DecentExposure
     helper_method name
     hide_action name
   end
+
+  def expose!(name, filter_options = {}, &block)
+    expose(name, &block)
+    before_filter name, filter_options
+  end
 end

--- a/spec/lib/decent_exposure_spec.rb
+++ b/spec/lib/decent_exposure_spec.rb
@@ -6,12 +6,14 @@ describe DecentExposure do
     extend DecentExposure
     def self.helper_method(*args); end
     def self.hide_action(*args); end
+    def self.before_filter(*args); end
     def memoizable(arg); arg; end
   end
 
   context 'classes extending DecentExposure' do
     subject { Controller }
     specify { should respond_to(:expose) }
+    specify { should respond_to(:expose!) }
     specify { should respond_to(:default_exposure) }
   end
 
@@ -74,6 +76,35 @@ describe DecentExposure do
           instance.default.should == "I got: 'default'"
         end
       end
+    end
+  end
+
+  context '.expose!' do
+    let(:controller) { Class.new(Controller){ expose(:resource) } }
+    let(:instance) { controller.new }
+
+    it 'creates a method with the given name' do
+      instance.should respond_to(:resource)
+    end
+
+    it 'prevents the method from being a callable action' do
+      controller.expects(:hide_action).with(:resources)
+      controller.class_eval { expose!(:resources) }
+    end
+
+    it 'declares the method as a helper method' do
+      controller.expects(:helper_method).with(:resources)
+      controller.class_eval { expose!(:resources) }
+    end
+
+    it 'adds a before filter to pre-cache the method' do
+      controller.expects(:before_filter).with(:resources, {})
+      controller.class_eval { expose!(:resources) }
+    end
+
+    it 'sends options along to before filter' do
+      controller.expects(:before_filter).with(:resources, :only => [:index, :custom])
+      controller.class_eval { expose!(:resources, :only => [:index, :custom]) }
     end
   end
 end


### PR DESCRIPTION
I've run into several occasions where I've wanted to pre-fetch resources. This is usually for a show action, where the appropriate error needs to be raised in the controller rather than in the view.

I don't mean for this to be _the_ implementation, but merely a conversation piece.

This implementation is modeled from RSpec's let and let! methods,
wherein the bang variation simply adds a before filter to pre-fetch and
cache the block.

The expose! method does take an options hash, which is passed on the
before_filter itself. This allows for only some actions to do the
caching, i.e. with the :only option.
