### PR TITLE
Support for Object.from_param

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+FORK: This fork adds support for slugs (aka: permalinks) through `Object.from_param`. If the Object responds to `from_param` then that method will be used instead of `find`
+
 `decent_exposure` helps you program to an interface, rather than an implementation in
 your Rails controllers.
 

--- a/lib/decent_exposure/default_exposure.rb
+++ b/lib/decent_exposure/default_exposure.rb
@@ -16,7 +16,8 @@ module DecentExposure
         end
 
         if id = params["#{name}_id"] || params[:id]
-          proxy.find(id).tap do |r|
+          find_method = if proxy.respond_to?(:from_param) then :from_param else :find end
+          proxy.send(find_method, id).tap do |r|
             r.attributes = params[name] unless request.get?
           end
         else


### PR DESCRIPTION
A small patch to allow models to define a `from_param` method that can be used for slug/permalink urls.
Define both `to_param` and a `self.from_param(id)` methods in your model and get nice url's for free!

example model:

```
class Person
  include Mongoid::Document
  field :name
  validates_uniqueness_of :name

  def to_param
    name
  end

  def self.from_param(param)
    self.where(name: param).first
  end
end
```
