### PR TITLE
Allow exposed resources to be overridden by similarly named instance variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ In the straightforward case, the three exposed resources above provide for
 access to both the primary and ancestor resources in a way usable across all 7
 actions in a typicall Rails-style RESTful controller.
 
+You can also manually supply resources in a controller by setting an instance variable:
+
+  def index
+    @product = Product.find_by_slug!(params[:product_id])
+  end
+
 #### A Note on Style
 
 When the code has become complex enough to surpass a single line (and is not

--- a/lib/decent_exposure.rb
+++ b/lib/decent_exposure.rb
@@ -19,12 +19,18 @@ module DecentExposure
   def expose(name, &block)
     closured_exposure = default_exposure
     define_method name do
-      @_resources       ||= {}
-      @_resources[name] ||= if block_given?
-        instance_eval(&block)
-      else
-        instance_exec(name, &closured_exposure)
+      resource = instance_variable_get("@#{name}")
+      if !resource
+        resource = if block_given?
+          instance_eval(&block)
+        else
+          instance_exec(name, &closured_exposure)
+        end
+
+        instance_variable_set "@#{name}", resource
       end
+
+      return resource
     end
     helper_method name
     hide_action name

--- a/spec/lib/decent_exposure_spec.rb
+++ b/spec/lib/decent_exposure_spec.rb
@@ -48,6 +48,11 @@ describe DecentExposure do
         instance.expects(:memoizable).once.returns('value')
         2.times { instance.resource }
       end
+
+      it 'returns the value of a similarly named instance variable' do
+        instance.instance_variable_set('@resource', "I'm an instance var!")
+        instance.resource.should == "I'm an instance var!"
+      end
     end
 
     context '.default_exposure' do


### PR DESCRIPTION
Basically if you have one funky method you don't have to break all your views:

expose(:product)

```
def index
  @product = Product.find_by_slug('foo')
  render product
end
```
