### PR TITLE
append _collection for uncountable resources

### DIFF
--- a/lib/decent_exposure/default_exposure.rb
+++ b/lib/decent_exposure/default_exposure.rb
@@ -9,6 +9,7 @@ module DecentExposure
       end
       klass.default_exposure do |name|
         collection = name.to_s.pluralize
+        collection += "_collection" if name.to_s == collection
         if respond_to?(collection) && collection != name.to_s && send(collection).respond_to?(:scoped)
           proxy = send(collection)
         else

--- a/spec/lib/rails_integration_spec.rb
+++ b/spec/lib/rails_integration_spec.rb
@@ -105,6 +105,18 @@ describe "Rails' integration:", DecentExposure do
           instance.person
         end
       end
+
+      context 'appends _collection to uncountable collections' do
+        let(:collection){ mock(:scoped => [self]) }
+
+        before{ controller.expose(:sheep) }
+
+        it 'uses the existing collection method' do
+          instance.stubs(:sheep_collection).returns(collection)
+          collection.expects(:new)
+          instance.sheep
+        end
+      end
     end
 
     context 'when either :resource_id or :id are present in params' do


### PR DESCRIPTION
DecentExposure should work with uncountable resources. I made a patch to simply append `_collection` to the collection resource when the resource is uncountable.

``` ruby
class SheepController < ApplicationController
  expose(:sheep_collection) { Sheep.alive }
  expose(:sheep)
end
```

In the example above, the sheep resource will be built with the scope of `sheep_collection`
