### PR TITLE
Make the default exposure send an empty hash when the resource params are nil

### DIFF
--- a/lib/decent_exposure/default_exposure.rb
+++ b/lib/decent_exposure/default_exposure.rb
@@ -20,7 +20,7 @@ module DecentExposure
             r.attributes = params[name] unless request.get?
           end
         else
-          proxy.new(params[name])
+          proxy.new(params[name]||{})
         end
       end
     end

--- a/spec/lib/rails_integration_spec.rb
+++ b/spec/lib/rails_integration_spec.rb
@@ -123,13 +123,26 @@ describe "Rails' integration:", DecentExposure do
       end
     end
     context 'when there are no ids in params' do
-      before do
-        instance.stubs(:params).returns({:resource => {:name => 'bob'}})
+      context "and there are no params for the resource" do
+        before do
+          instance.stubs(:params).returns({})
+        end
+
+        it 'calls new with params[:resouce_name]' do
+          Resource.expects(:new).with({})
+          instance.resource
+        end
       end
 
-      it 'calls new with params[:resouce_name]' do
-        Resource.expects(:new).with({:name => 'bob'})
-        instance.resource
+      context "and there are params for the resource" do
+        before do
+          instance.stubs(:params).returns({:resource => {:name => 'bob'}})
+        end
+
+        it 'calls new with params[:resouce_name]' do
+          Resource.expects(:new).with({:name => 'bob'})
+          instance.resource
+        end
       end
     end
   end


### PR DESCRIPTION
If the resource param is nil, it sends to the initialize method as `nil`.  Because of this, every initialize method must handle 3 types of values: default value ({}), nil value, and a hash with given values.

We are not using ActiveRecord, Mongoid, or any other ORM.  For each model we use decent exposure with, we have to do the following:

``` ruby
  def initialize(hash={})
    hash ||= {} # do not want to do this!
    self.some_attribute = hash[:some_attribute]
  end
```
