### PR TITLE
Nils are values too!

### DIFF
--- a/lib/decent_exposure.rb
+++ b/lib/decent_exposure.rb
@@ -20,10 +20,12 @@ module DecentExposure
     closured_exposure = default_exposure
     define_method name do
       @_resources       ||= {}
-      @_resources[name] ||= if block_given?
-        instance_eval(&block)
-      else
-        instance_exec(name, &closured_exposure)
+      @_resources.fetch(name) do
+        @_resources[name] = if block_given?
+          instance_eval(&block)
+        else
+          instance_exec(name, &closured_exposure)
+        end
       end
     end
     helper_method name

--- a/spec/lib/decent_exposure_spec.rb
+++ b/spec/lib/decent_exposure_spec.rb
@@ -48,6 +48,19 @@ describe DecentExposure do
         instance.expects(:memoizable).once.returns('value')
         2.times { instance.resource }
       end
+
+      context "with a nil result" do
+        before do
+          controller.class_eval do
+            expose(:resource) { memoizable(nil) }
+          end
+        end
+
+        it 'memoizes the value of the created method' do
+          instance.expects(:memoizable).once.returns(nil)
+          2.times { instance.resource }
+        end
+      end
     end
 
     context '.default_exposure' do


### PR DESCRIPTION
When the exposure block returns a nil, that value should be returned
instead of re-running the exposure block when the method is re-invoked.

If the exposure encapsulates a long-running operation, you don't want
that to run multiple times.

expose(:foo) { sleep 10; nil }
Bechmark.realtime { foo; foo} = 20 secs, instead of 10 seconds
