### PR TITLE
Blacklist @_resources from views

### DIFF
--- a/lib/decent_exposure/railtie.rb
+++ b/lib/decent_exposure/railtie.rb
@@ -14,6 +14,7 @@ module DecentExposure
   class Railtie
     def self.insert
       ActionController::Base.send(:include, DecentExposure::DefaultExposure)
+      ActionController::Base.protected_instance_variables.push("@_resources")
     end
   end
 end

--- a/spec/lib/rails_integration_spec.rb
+++ b/spec/lib/rails_integration_spec.rb
@@ -26,6 +26,17 @@ describe "Rails' integration:", DecentExposure do
     instance.stubs(:request).returns(request)
   end
 
+  context 'when inserting decent exposure' do
+
+    let(:blacklist) do
+      ActionController::Base.protected_instance_variables
+    end
+
+    it 'blacklists the @_resources instance variable' do
+      blacklist.should include("@_resources")
+    end
+  end
+
   context '.expose' do
     it 'is available to ActionController::Base' do
       ActionController::Base.should respond_to(:expose)


### PR DESCRIPTION
Currently, the `@_resources` instance variable that decent exposure encapsulates is still available in the views. Normally this is not an issue since the exposures are lazily evaluated and if the view is the first to call the defined helper method then `@_resources` will always be nil. However if the controller is the first to access the exposure for whatever reason, the value will be in the resources hash and also in the view.

This pull request explicitly blacklists the `@_resources` instance variable so it is now truly encapsulated by the controller.
