### PR TITLE
Sketch of parameter filtering (nunu)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ Specify the finder method:
 
     expose(:company, finder: :find_by_slug)
 
+Specify the parameter accessor:
+
+    expose(:company, params: :company_params)
+
 ### Getting your hands dirty
 
 While we try to make things as easy for you as possible, sometimes you just

--- a/sketch.rb
+++ b/sketch.rb
@@ -232,6 +232,20 @@ class Controller
   expose(:whatever, model: :thing)
   expose(:whatever, model: :thing, :finder: :find_by_thing, scope: :things)
 
+  # filtering parameters
+  expose(:whatever, attributes: [:ok, :also_ok])
+
+  # using a custom / filtered set of parameters
+  expose(:whatever, params: :whatever_params)
+  def whatever_params
+    attrs = params[:whatever] || {}
+    if current_user.admin?
+      attrs.slice(:ok, :also_ok, :ok_for_admin)
+    else
+      attrs.slice(:ok, :also_ok)
+    end
+  end
+
   # using the default behavior of decent_exposure with an app specific twist
   expose(:whatever, orm: :data_mapper) { app_specific(framework.execute_default) }
 


### PR DESCRIPTION
It looks like nunu is a sketch and a refactoring of the existing API, moving towards the sketch/README. So I've updated the sketch & readme with the idea from #38. In that issue, @voxdolo suggested configuring a default in an `exposure` block, but it seems like it's simpler to configure per-`expose`, so that's what I've sketched.

(a) Does this look good?

(b) What's the next step I can take to help make a configurable `params` (or nunu) a reality?
