### PR TITLE
Add 'class_name' option

### DIFF
--- a/lib/decent_exposure.rb
+++ b/lib/decent_exposure.rb
@@ -16,7 +16,7 @@ module DecentExposure
     _default_exposure
   end
 
-  def expose(name, &block)
+  def expose(name, opts = {}, &block)
     closured_exposure = default_exposure
     define_method name do
       @_resources       ||= {}
@@ -24,7 +24,8 @@ module DecentExposure
         @_resources[name] = if block_given?
           instance_eval(&block)
         else
-          instance_exec(name, &closured_exposure)
+          class_name = opts[:class_name] ? opts[:class_name].downcase : name
+          instance_exec(class_name, &closured_exposure)
         end
       end
     end

--- a/spec/lib/rails_integration_spec.rb
+++ b/spec/lib/rails_integration_spec.rb
@@ -70,6 +70,19 @@ describe "Rails' integration:", DecentExposure do
       Resource.stubs(:find).returns('preserved')
       instance.resource.should == 'preserved'
     end
+
+    context "with class_name option" do
+      let(:params) { HashWithIndifferentAccess.new(:equipment_id => 42) }
+
+      before do
+        resource_controller.expose(:resource, :class_name => 'Equipment')
+      end
+
+      it 'should call the different class' do
+        Equipment.stubs(:find).returns('equipment')
+        instance.resource.should == 'equipment'
+      end
+    end
   end
 
   context '.default_exposure' do


### PR DESCRIPTION
Now we can use :class_name option if we need to use different class

``` ruby
class BusinessClientController < ApplicationController
  expose(:client, :class_name => 'BusinessClient')

  def create
    client.save!
    redirect_to client
  end
end
```
