### PR TITLE
Provide a declarative way of scoping on other exposed objects

### DIFF
--- a/lib/decent_exposure.rb
+++ b/lib/decent_exposure.rb
@@ -16,7 +16,7 @@ module DecentExposure
     _default_exposure
   end
 
-  def expose(name, &block)
+  def expose(name, options = {}, &block)
     closured_exposure = default_exposure
     define_method name do
       @_resources       ||= {}
@@ -24,7 +24,11 @@ module DecentExposure
         @_resources[name] = if block_given?
           instance_eval(&block)
         else
-          instance_exec(name, &closured_exposure)
+          if options[:through]
+            instance_eval { send(options[:through]).send(name) }
+          else
+            instance_exec(name, options, &closured_exposure)
+          end
         end
       end
     end


### PR DESCRIPTION
This let's you do the following

``` ruby
expose :user
expose :comments, :through => :user
```

Obviously you could just do

``` ruby
expose(:comments) { user.comments }
```

But to my eye, the declarative syntax improves readability.
1. If there's interest in this change, I can spend some time updating specs and readme
2. It might be time to factor the fetch block out of the expose method
