### PR TITLE
Add 'class_name' option and support namespaces

### DIFF
--- a/lib/decent_exposure.rb
+++ b/lib/decent_exposure.rb
@@ -24,8 +24,7 @@ module DecentExposure
         @_resources[name] = if block_given?
           instance_eval(&block)
         else
-          class_name = opts[:class_name] ? opts[:class_name].downcase : name
-          instance_exec(class_name, &closured_exposure)
+          instance_exec(name, opts, &closured_exposure)
         end
       end
     end

--- a/lib/decent_exposure/default_exposure.rb
+++ b/lib/decent_exposure/default_exposure.rb
@@ -7,12 +7,13 @@ module DecentExposure
       else
         klass.superclass_delegating_accessor(:_default_exposure)
       end
-      klass.default_exposure do |name|
+      klass.default_exposure do |name, opts={}|
         collection = name.to_s.pluralize
         if respond_to?(collection) && collection != name.to_s && send(collection).respond_to?(:scoped)
           proxy = send(collection)
         else
-          proxy = name.to_s.classify.constantize
+          class_name = opts[:class_name] || name
+          proxy = class_name.to_s.classify.constantize
         end
 
         if id = params["#{name}_id"] || params[:id]

--- a/spec/lib/rails_integration_spec.rb
+++ b/spec/lib/rails_integration_spec.rb
@@ -15,6 +15,14 @@ class Equipment
   def initialize(*args); end
 end
 
+module My
+  class Resource
+    def self.scoped(opts); self; end
+    def self.find(*args); end
+    def initialize(*args); end
+  end
+end
+
 describe "Rails' integration:", DecentExposure do
   let(:controller) { Class.new(ActionController::Base) }
   let(:instance) { controller.new }
@@ -72,16 +80,20 @@ describe "Rails' integration:", DecentExposure do
     end
 
     context "with class_name option" do
-      let(:params) { HashWithIndifferentAccess.new(:equipment_id => 42) }
+      let(:params) { HashWithIndifferentAccess.new(:resource_id => 42) }
 
-      before do
-        resource_controller.expose(:resource, :class_name => 'Equipment')
+      it 'should call the different class when given a constant' do
+        resource_controller.expose(:resource, :class_name => My::Resource)
+        My::Resource.should_receive(:find).and_return('my::resource')
+        instance.resource.should == 'my::resource'
       end
 
-      it 'should call the different class' do
-        Equipment.stubs(:find).returns('equipment')
-        instance.resource.should == 'equipment'
+      it 'should call the different class when given a string' do
+        resource_controller.expose(:resource, :class_name => 'My::Resource')
+        My::Resource.should_receive(:find).and_return('my::resource')
+        instance.resource.should == 'my::resource'
       end
+
     end
   end
 


### PR DESCRIPTION
This includes a commit from #43 created by @paranoiase. It extends his original concept to work with models given as constant or string, with or without namespaces.
