### PR TITLE
Fixes case with "expose :account_address"

### DIFF
--- a/lib/decent_exposure/default_exposure.rb
+++ b/lib/decent_exposure/default_exposure.rb
@@ -12,7 +12,7 @@ module DecentExposure
         if respond_to?(collection) && collection != name.to_s && send(collection).respond_to?(:scoped)
           proxy = send(collection)
         else
-          proxy = name.to_s.classify.constantize
+          proxy = name.to_s.pluralize.classify.constantize
         end
 
         if id = params["#{name}_id"] || params[:id]


### PR DESCRIPTION
Problem:

If I want to expose account_address, it gets classified as AccountAddres.

Solution:

If I pluralize symbol name first to account_addresses,
it gets classified correctly to AccountAddress
