### PR TITLE
Deprecate default exposure

### DIFF
--- a/lib/decent_exposure/expose.rb
+++ b/lib/decent_exposure/expose.rb
@@ -26,6 +26,10 @@ module DecentExposure
     end
 
     def default_exposure(&block)
+      warn "[DEPRECATION] `default_exposure` is deprecated, and will " \
+      "be remove in DecentExposure 2.1 without a replacement.  Please " \
+      "use a custom strategy instead.\n" \
+      "#{caller.first}"
       self._default_exposure = block
     end
 


### PR DESCRIPTION
Default exposure is the last remaining hackiness from earlier versions
of Decent Exposure. Custom strategy classes are much more flexible,
robust, and less error-prone. They are also testable. Let's deprecate
default exposures.
