### PR TITLE
fix eager attribute for DELETE requests

### DIFF
--- a/lib/decent_exposure/active_record_with_eager_attributes_strategy.rb
+++ b/lib/decent_exposure/active_record_with_eager_attributes_strategy.rb
@@ -3,8 +3,6 @@ require 'decent_exposure/active_record_strategy'
 module DecentExposure
   class ActiveRecordWithEagerAttributesStrategy < ActiveRecordStrategy
     delegate :get?,    :to => :request
-    delegate :post?,   :to => :request
-    delegate :put?,    :to => :request
     delegate :delete?, :to => :request
 
     def singular?

--- a/spec/decent_exposure/active_record_with_eager_attributes_strategy_spec.rb
+++ b/spec/decent_exposure/active_record_with_eager_attributes_strategy_spec.rb
@@ -25,8 +25,6 @@ describe DecentExposure::ActiveRecordWithEagerAttributesStrategy do
         let(:request) { double("Request") }
         before do
           request.stub(:get?    => true)
-          request.stub(:post?   => false)
-          request.stub(:put?    => false)
           request.stub(:delete? => false)
         end
         it "ignores the attributes" do
@@ -44,8 +42,6 @@ describe DecentExposure::ActiveRecordWithEagerAttributesStrategy do
         let(:request) { double("Request") }
         before do
           request.stub(:get?    => false)
-          request.stub(:post?   => true)
-          request.stub(:put?    => false)
           request.stub(:delete? => false)
         end
         it "sets the attributes from the request" do
@@ -63,8 +59,6 @@ describe DecentExposure::ActiveRecordWithEagerAttributesStrategy do
         let(:request) { double("Request") }
         before do
           request.stub(:get?    => false)
-          request.stub(:post?   => false)
-          request.stub(:put?    => true)
           request.stub(:delete? => false)
         end
         it "sets the attributes from the request" do
@@ -82,8 +76,6 @@ describe DecentExposure::ActiveRecordWithEagerAttributesStrategy do
         let(:request) { double("Request") }
         before do
           request.stub(:get?    => false)
-          request.stub(:post?   => false)
-          request.stub(:put?    => false)
           request.stub(:delete? => true)
         end
         it "ignores the attributes" do


### PR DESCRIPTION
We shouldn't attempt to set attributes on DELETE requests. Doing so proves problematic when using strong_parameters.
