### PR TITLE
Introduce strategy for use with strong_parameters

### DIFF
--- a/lib/decent_exposure/strategizer.rb
+++ b/lib/decent_exposure/strategizer.rb
@@ -1,5 +1,6 @@
 require 'decent_exposure/exposure'
 require 'decent_exposure/active_record_with_eager_attributes_strategy'
+require 'decent_exposure/strong_parameters_strategy'
 
 module DecentExposure
   class Strategizer

--- a/lib/decent_exposure/strong_parameters_strategy.rb
+++ b/lib/decent_exposure/strong_parameters_strategy.rb
@@ -1,0 +1,27 @@
+require 'decent_exposure/active_record_strategy'
+
+module DecentExposure
+  class StrongParametersStrategy < ActiveRecordStrategy
+    delegate :get?,    :to => :request
+    delegate :delete?, :to => :request
+
+    def singular?
+      !plural?
+    end
+
+    def attributes
+      return @attributes if defined?(@attributes)
+      @attributes = controller.send(options[:attributes]) if options[:attributes]
+    end
+
+    def assign_attributes?
+      singular? && !get? && !delete? && attributes.present?
+    end
+
+    def resource
+      super.tap do |r|
+        r.attributes = attributes if assign_attributes?
+      end
+    end
+  end
+end

--- a/spec/decent_exposure/strong_parameters_strategy_spec.rb
+++ b/spec/decent_exposure/strong_parameters_strategy_spec.rb
@@ -1,0 +1,57 @@
+require 'decent_exposure/strong_parameters_strategy'
+require 'active_support/core_ext'
+
+describe DecentExposure::StrongParametersStrategy do
+  describe "#assign_attributes?" do
+    let(:inflector) do
+      double("Inflector", :plural? => plural)
+    end
+    let(:plural) { false }
+    let(:request) { stub(:get? => true) }
+    let(:controller) { stub(:params => {}, :request => request) }
+    let(:options) { {} }
+    let(:strategy) { described_class.new(controller, inflector, options) }
+
+    subject { strategy.assign_attributes? }
+
+    context "when the resource is a collection (plural)" do
+      let(:plural) { true }
+      it { should be_false }
+    end
+
+    context "for a get request" do
+      let(:request) { stub(:get? => true, :delete? => false) }
+      it { should be_false }
+    end
+
+    context "for a delete request" do
+      let(:request) { stub(:delete? => true, :get? => false) }
+      it { should be_false }
+    end
+
+    context "for a post/put/patch request" do
+      let(:request) { stub(:get? => false, :delete? => false) }
+
+      context "and the :attributes option is set" do
+        let(:options) { { :attributes => :my_attributes } }
+        before do
+          controller.stub(:my_attributes).and_return(results)
+        end
+
+        context "and sending the attributes method returns a non-blank value" do
+          let(:results) { { :hello => "there" } }
+          it { should be_true }
+        end
+
+        context "and sending the attributes method returns a blank value" do
+          let(:results) { {} }
+          it { should be_false }
+        end
+      end
+
+      context "and the :attributes option is not set" do
+        it { should be_false }
+      end
+    end
+  end
+end

--- a/spec/fixtures/controllers.rb
+++ b/spec/fixtures/controllers.rb
@@ -108,6 +108,25 @@ end
 
 class MallardController < DuckController; end
 
+class StrongParametersController < ActionController::Base
+  include Rails.application.routes.url_helpers
+
+  decent_configuration do
+    strategy DecentExposure::StrongParametersStrategy
+  end
+
+  expose(:assignable, :attributes => :assignable_attributes, :model => Parrot)
+  expose(:unassignable, :model => Parrot)
+
+  def show
+    render :text => "show"
+  end
+
+  def assignable_attributes
+    params[:assignable]
+  end
+end
+
 class ::Model
   def self.find(*); new end
   def name; "outer" end

--- a/spec/fixtures/fake_rails_application.rb
+++ b/spec/fixtures/fake_rails_application.rb
@@ -21,6 +21,7 @@ module Rails
         get '/mallard/(:id)' => "mallard#show"
         get '/taxonomies/(:id)' => "taxonomies#show"
         get '/namespace/model/:id' => "namespace/model#show"
+        get '/strong_parameters/:id' => "strong_parameters#show"
       end
       @routes
     end

--- a/spec/rails_integration_spec.rb
+++ b/spec/rails_integration_spec.rb
@@ -136,6 +136,37 @@ describe MallardController, :type => :controller do
 
 end
 
+describe StrongParametersController, :type => :controller do
+  describe "attribute setting" do
+
+    context "with an 'attributes' option set" do
+      let(:request) { [:show, { :id => 2, :assignable => { :beak => "droopy" } }] }
+      it "assigns attributes for post requests, using the method from 'attributes'" do
+        post *request
+        controller.assignable.beak.should == "droopy"
+      end
+
+      it "assigns attributes for post requests, using the method from 'attributes'" do
+        put *request
+        controller.assignable.beak.should == "droopy"
+      end
+
+      it "does not assign attributes on get requests" do
+        get *request
+        controller.assignable.beak.should_not == "droopy"
+      end
+    end
+
+    context "with no 'attributes' option set" do
+      let(:request) { [:show, { :id => 2, :unassignable => { :beak => "droopy" } }] }
+      it "does not assign attributes" do
+        post *request
+        controller.assignable.beak.should_not == "droopy"
+      end
+    end
+  end
+end
+
 describe TaxonomiesController, :type => :controller do
   describe 'default configration' do
     it 'uses the configured finder' do


### PR DESCRIPTION
This works similarly to ActiveRecordWithEagerAttributesStrategy, but for
attributes to be assigned, you must provide the name of the method to be
called, via the :attributes option to the `expose` call.

The assumption here is you'll define a private method in the controller
and use strong parameters, as:

```
expose(:foo, attributes: :foo_params)

def foo_params
  params.require(:foo).permit(:bar, :baz)
end
```

Once merged, this should close out #59 
