### PR TITLE
Rails 4 scoped deprecation warning

### DIFF
--- a/lib/decent_exposure/active_record_strategy.rb
+++ b/lib/decent_exposure/active_record_strategy.rb
@@ -38,7 +38,7 @@ module DecentExposure
     end
 
     def collection_resource
-      scope.scoped
+      Rails::VERSION::MAJOR < 4 ? scope.scoped : scope.all
     end
 
     def id


### PR DESCRIPTION
DEPRECATION WARNING: Model.scoped is deprecated. Please use Model.all instead.
