### PR TITLE
Pass name to the options hash.

### DIFF
--- a/lib/decent_exposure/strategizer.rb
+++ b/lib/decent_exposure/strategizer.rb
@@ -9,7 +9,7 @@ module DecentExposure
     def initialize(name, options={})
       self.name = name
       self.custom_strategy_class = options.delete(:strategy)
-      self.options = options
+      self.options = options.merge(:name => name)
       self.block = Proc.new if block_given?
     end
 

--- a/spec/decent_exposure/strategizer_spec.rb
+++ b/spec/decent_exposure/strategizer_spec.rb
@@ -20,7 +20,7 @@ describe DecentExposure::Strategizer do
         let(:name) { "exposed" }
 
         it "initializes a provided class" do
-          DecentExposure::Exposure.should_receive(:new).with(name, strategy,{}).and_return(instance)
+          DecentExposure::Exposure.should_receive(:new).with(name, strategy,{:name => name}).and_return(instance)
           should == instance
         end
       end
@@ -33,7 +33,7 @@ describe DecentExposure::Strategizer do
 
         it "sets the strategy to Active Record" do
           DecentExposure::Exposure.should_receive(:new).
-            with(model_option, DecentExposure::ActiveRecordWithEagerAttributesStrategy, {:model => :other}).
+            with(model_option, DecentExposure::ActiveRecordWithEagerAttributesStrategy, {:model => :other, :name => name}).
             and_return(strategy)
           should == strategy
         end


### PR DESCRIPTION
When I use an exposure like this one

``` ruby
exposure :published_documents, model: Document
```

the inflector will get the Document class and not the name of the exposure as parameter. This will work fine, unless you start using your own strategies (this one uses Draper to decorate all resources):

``` ruby
class DecoratedStrategy < DecentExposure::StrongParametersStrategy
  def singular_resource
    decorator.decorate(super)
  end

  def collection_resource
    decorator.decorate_collection(super)
  end

private
  def decorator
    "#{inflector.singular.classify}Decorator".constantize
  end
end
```

The problem is, that the inflector for my `published_documents` will always return `false` when calling `plural?` on it, because he is only testing the Document class name which will never be plural.

**Two solutions**  
1. We could pass the name of exposure to the inflector, even if a custom `:model` option is used. This could maybe break existing exposures.
2. Or we could just pass the name of the exposure to the options hash, so each exposure is aware of its own name (and we can later do fancy stuff with it).

This is the pull request for option 2! @voxdolo, please let me know what you think. :)

-@haihappen
