### PR TITLE
sends default behavior in the override block

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,20 @@ expose(:environment) { Rails.env }
 This block is evaluated and the memoized result is returned whenever you call
 `environment`.
 
+#### Using the Default decent_exposure Goodness
+
+If you don't want to go too far off the beaten path, the value of the default
+exposure can be easily obtained inside of your custom block. The block will
+receive an object that you can `call` to lazily evaluate the default
+decent_exposure logic. For example:
+
+```ruby
+expose(:articles) {|default| default.call.limit(10) }
+```
+
+This allows you to customize your exposures, without having to redo all of
+the built-in logic decent_exposure gives you out of the box.
+
 ### Custom strategies
 
 For the times when custom behavior is needed for resource finding,

--- a/lib/decent_exposure/strategizer.rb
+++ b/lib/decent_exposure/strategizer.rb
@@ -34,8 +34,8 @@ module DecentExposure
 
   BlockStrategy = Struct.new(:block, :exposure_strategy) do
     def call(controller)
-      default = if block.arity == 1
-        exposure_strategy.call(controller) rescue nil
+      default = Proc.new do
+        exposure_strategy.call(controller)
       end
       controller.instance_exec(default, &block)
     end

--- a/spec/decent_exposure/strategizer_spec.rb
+++ b/spec/decent_exposure/strategizer_spec.rb
@@ -5,10 +5,48 @@ describe DecentExposure::Strategizer do
     subject { exposure.strategy }
 
     context "when a block is given" do
-      let(:block) { lambda { "foo" } }
+      let(:block) { lambda {|default| "foo" } }
       let(:exposure) { DecentExposure::Strategizer.new("foobar", &block) }
       it "saves the proc as the strategy" do
         subject.block.should == block
+      end
+
+      context "with a default object" do
+        let(:exposure_strategy) { Proc.new { "default" } }
+        let(:strategy) { exposure.strategy }
+        let(:controller) { double("Controller") }
+
+        before do
+          exposure.stub(:exposure_strategy) { exposure_strategy }
+        end
+
+        context "that doesn't get called" do
+          let(:block) { lambda{|default| "foo" } }
+
+          it "doesn't call the exposure_strategy" do
+            exposure_strategy.should_not_receive(:call)
+          end
+
+          it "returns the block value" do
+            strategy.call(controller).should == "foo"
+          end
+        end
+
+        context "that does get called" do
+          let(:block) { lambda{|default| default.call } }
+
+          it "calls the exposure strategy" do
+            exposure_strategy.should_receive(:call).with(controller)
+          end
+
+          it "returns the default value" do
+            strategy.call(controller).should == "default"
+          end
+        end
+
+        after do
+          strategy.call(controller)
+        end
       end
     end
 


### PR DESCRIPTION
Here's an idea for issue #70 regarding providing a way to use the default exposure in an override block. This will execute and send the default exposure if the blocks arity is 1, and it doesn't throw a name exception. still needs tests, and probably finer exception handling, but it's a thought. i tried it in a local rails project and it produced the expected results:

```
class ProductsController < ApplicationController
  expose(:products) {|default| default.limit(2) }
  expose(:product)

  def index

  end
end
```

do you like this direction? maybe you can give me some input to improve it?
