### PR TITLE
expose(:foo, permit: [:bar, :baz])

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,21 +385,15 @@ end
 ```
 
 Then, when you'd like parameters to be assigned to a model, add the
-`attributes` option to your exposure:
+`permit` option to your exposure:
 
 ```ruby
 class FooController < ApplicationController
-  expose(:foo, attributes: :foo_params)
-
-  private
-  def foo_params
-    params.require(:foo).permit(:bar, :baz)
-  end
+  expose(:foo, permit: [:bar, :baz])
 end
 ```
 
-In the example above, `foo_params` will only be called on a PUT, POST or
-PATCH request.
+In the examples above, the :bar and :baz parameters will only be assigned on a PUT, POST or PATCH request.
 
 
 ## Testing

--- a/lib/decent_exposure/strong_parameters_strategy.rb
+++ b/lib/decent_exposure/strong_parameters_strategy.rb
@@ -11,7 +11,11 @@ module DecentExposure
 
     def attributes
       return @attributes if defined?(@attributes)
-      @attributes = controller.send(options[:attributes]) if options[:attributes]
+      if options[:permit].present?
+        @attributes = params.require(name.to_sym).permit(*options[:permit])
+      else
+        @attributes = controller.send(options[:attributes]) if options[:attributes]
+      end
     end
 
     def assign_attributes?

--- a/spec/decent_exposure/strong_parameters_strategy_spec.rb
+++ b/spec/decent_exposure/strong_parameters_strategy_spec.rb
@@ -36,11 +36,8 @@ describe DecentExposure::StrongParametersStrategy do
     context "for a post/put/patch request" do
       let(:request) { stub(:get? => false, :delete? => false) }
 
-      context "and the :attributes option is set" do
-        let(:options) { { :attributes => :my_attributes } }
-        before do
-          controller.stub(:my_attributes).and_return(results)
-        end
+      context "and the :permit option is set" do
+        let(:options) { { :permit => [:hello] } }
 
         context "and sending the attributes method returns a non-blank value" do
           let(:results) { { :hello => "there" } }
@@ -53,7 +50,7 @@ describe DecentExposure::StrongParametersStrategy do
         end
       end
 
-      context "and the :attributes option is not set" do
+      context "and the :permit option is not set" do
         it { should be_false }
       end
     end


### PR DESCRIPTION
Add a permit option rather than specifying a method for attributes to permit params.

``` ruby
class FooController < ApplicationController
  expose(:foo, attributes: :foo_params)

  private
  def foo_params
    params.require(:foo).permit(:bar, :baz)
  end
end
```

becomes

``` ruby
class FooController < ApplicationController
  expose(:foo, permit: [:bar, :baz])
end
```

I'm a noob and couldn't get the specs Inflector mock to play ball..
"no implicit conversion of Symbol into String"

But, the implementation is behaving as I expect.
