### PR TITLE
Error while setting a plural exposure with a model configuration

### DIFF
--- a/lib/decent_exposure/exposure.rb
+++ b/lib/decent_exposure/exposure.rb
@@ -5,7 +5,7 @@ module DecentExposure
     attr_accessor :name, :strategy, :options
 
     def initialize(name, strategy, options)
-      self.name = name.to_s
+      self.name = options[:name].to_s
       self.strategy = strategy
       self.options = options
     end

--- a/spec/fixtures/controllers.rb
+++ b/spec/fixtures/controllers.rb
@@ -42,6 +42,9 @@ class Organism
   def self.find_by_itis_id(itis_id)
     new
   end
+  def self.scoped
+    [new, new]
+  end
   def self.find(id)
     new(:species => 'Striginae')
   end
@@ -75,6 +78,7 @@ class BirdController < ActionController::Base
   expose(:ostrich) { "Ostrich" }
   expose(:albatrosses)
   expose(:parrot)
+  expose(:organisms, :model => Organism)
 
   expose(:custom, :strategy => CustomStrategy)
 

--- a/spec/rails_integration_spec.rb
+++ b/spec/rails_integration_spec.rb
@@ -95,6 +95,14 @@ describe BirdController, :type => :controller do
     end
   end
 
+  describe "collection with plural name and model" do
+    it "scopes the resource to the collection" do
+      get :index
+      controller.organisms.each do |organism|
+        organism.should be_a Organism
+      end
+    end
+  end
 end
 
 describe DuckController, :type => :controller do


### PR DESCRIPTION
If you exposed something like this:

```
expose(:organisms, :model => Organism)
```

The index action would fail when trying to call organisms.
