### PR TITLE
Use test doubles in favor of stubs

### DIFF
--- a/spec/decent_exposure/active_record_strategy_spec.rb
+++ b/spec/decent_exposure/active_record_strategy_spec.rb
@@ -5,12 +5,12 @@ describe DecentExposure::ActiveRecordStrategy do
     let(:inflector) do
       double("Inflector", :parameter => "model_id", :plural? => plural, :plural => 'models', :singular => 'model')
     end
-    let(:model) { stub("Model", :new => nil) }
+    let(:model) { double("Model", :new => nil) }
     let(:params) { Hash.new }
-    let(:request) { stub(:get? => true) }
-    let(:config) { stub(:options => {}) }
-    let(:controller_class) { stub(:_decent_configurations => Hash.new(config)) }
-    let(:controller) { stub(:params => params, :request => request, :class => controller_class) }
+    let(:request) { double('request', :get? => true) }
+    let(:config) { double('config', :options => {}) }
+    let(:controller_class) { double('controller_class', :_decent_configurations => Hash.new(config)) }
+    let(:controller) { double('controller', :params => params, :request => request, :class => controller_class) }
     let(:strategy) { DecentExposure::ActiveRecordStrategy.new(controller, inflector) }
 
     before do
@@ -21,7 +21,7 @@ describe DecentExposure::ActiveRecordStrategy do
     subject { strategy.resource }
 
     context "with a singular resource" do
-      let(:instance) { stub }
+      let(:instance) { double }
       let(:plural) { false }
 
       context "with a findable resource" do
@@ -45,7 +45,7 @@ describe DecentExposure::ActiveRecordStrategy do
 
       context "with an unfindable resource" do
         let(:params) { { } }
-        let(:builder) { stub }
+        let(:builder) { double }
         it "it builds a new instance of the resource" do
           model.should_receive(:new).and_return(instance)
           should == instance
@@ -120,7 +120,7 @@ describe DecentExposure::ActiveRecordStrategy do
 
       context "with a parameter key override specified" do
         let(:params) { { :slug => 'article-title-slug' } }
-        let(:slug) { stub('Slug') }
+        let(:slug) { double('Slug') }
         let(:strategy) do
           DecentExposure::ActiveRecordStrategy.new(controller, inflector, :finder_parameter => :slug)
         end
@@ -134,13 +134,13 @@ describe DecentExposure::ActiveRecordStrategy do
 
     context "with a resource collection" do
       let(:plural) { true }
+      let(:scoped) { double('Scoped') }
 
       context "with ActiveRecord 3" do
         before do
           stub_const("ActiveRecord::VERSION::MAJOR", 3)
         end
         it "returns the scoped collection" do
-          scoped = stub
           model.should_receive(:scoped).and_return(scoped)
           should == scoped
         end
@@ -151,7 +151,6 @@ describe DecentExposure::ActiveRecordStrategy do
           stub_const("ActiveRecord::VERSION::MAJOR", 4)
         end
         it "returns the scoped collection" do
-          scoped = stub
           model.should_receive(:all).and_return(scoped)
           should == scoped
         end

--- a/spec/decent_exposure/active_record_with_eager_attributes_strategy_spec.rb
+++ b/spec/decent_exposure/active_record_with_eager_attributes_strategy_spec.rb
@@ -5,12 +5,12 @@ describe DecentExposure::ActiveRecordWithEagerAttributesStrategy do
     let(:inflector) do
       double("Inflector", :parameter => "model_id", :plural? => plural, :plural => 'models', :singular => 'model', :param_key => 'model')
     end
-    let(:model) { stub("Model", :new => nil) }
+    let(:model) { double("Model", :new => nil) }
     let(:params) { Hash.new }
-    let(:request) { stub(:get? => true) }
-    let(:config) { stub(:options => {}) }
-    let(:controller_class) { stub(:_decent_configurations => Hash.new(config)) }
-    let(:controller) { stub(:params => params, :request => request, :class => controller_class) }
+    let(:request) { double(:get? => true) }
+    let(:config) { double(:options => {}) }
+    let(:controller_class) { double(:_decent_configurations => Hash.new(config)) }
+    let(:controller) { double(:params => params, :request => request, :class => controller_class) }
     let(:strategy) { DecentExposure::ActiveRecordWithEagerAttributesStrategy.new(controller, inflector) }
 
     subject { strategy.resource }
@@ -93,7 +93,7 @@ describe DecentExposure::ActiveRecordWithEagerAttributesStrategy do
 
     context "when the params for the resource is nil" do
       let(:params) { {} }
-      let(:instance) { stub }
+      let(:instance) { double }
       let(:plural) { false }
 
       it "sends a empty hash to attributes=" do
@@ -108,7 +108,7 @@ describe DecentExposure::ActiveRecordWithEagerAttributesStrategy do
         { "model" => { "name" => "Timmy" } }
       end
       let(:plural) { false }
-      let(:instance) { stub }
+      let(:instance) { double }
       it "it builds a new instance of the resource" do
         model.should_receive(:new).and_return(instance)
         instance.should_receive(:attributes=)
@@ -120,7 +120,7 @@ describe DecentExposure::ActiveRecordWithEagerAttributesStrategy do
       let(:plural) { true }
       before { stub_const("ActiveRecord::VERSION::MAJOR", 3) }
       it "does not attempt to assign attributes" do
-        scoped = stub
+        scoped = double
         model.should_receive(:scoped).and_return(scoped)
         scoped.should_not_receive(:attributes=)
         should == scoped

--- a/spec/decent_exposure/strong_parameters_strategy_spec.rb
+++ b/spec/decent_exposure/strong_parameters_strategy_spec.rb
@@ -7,8 +7,8 @@ describe DecentExposure::StrongParametersStrategy do
       double("Inflector", :plural? => plural)
     end
     let(:plural) { false }
-    let(:request) { stub(:get? => true) }
-    let(:controller) { stub(:params => {}, :request => request) }
+    let(:request) { double('request', :get? => true) }
+    let(:controller) { double('controller', :params => {}, :request => request) }
     let(:options) { {} }
     let(:strategy) { described_class.new(controller, inflector, options) }
 
@@ -24,17 +24,17 @@ describe DecentExposure::StrongParametersStrategy do
     end
 
     context "for a get request" do
-      let(:request) { stub(:get? => true, :delete? => false) }
+      let(:request) { double('request', :get? => true, :delete? => false) }
       it { should be_false }
     end
 
     context "for a delete request" do
-      let(:request) { stub(:delete? => true, :get? => false) }
+      let(:request) { double('request', :delete? => true, :get? => false) }
       it { should be_false }
     end
 
     context "for a post/put/patch request" do
-      let(:request) { stub(:get? => false, :delete? => false) }
+      let(:request) { double('request', :get? => false, :delete? => false) }
 
       context "and the :attributes option is set" do
         let(:options) { { :attributes => :my_attributes } }


### PR DESCRIPTION
- Silences deprecation warnings from latest Rspec
