### PR TITLE
Fix nested exposures under Rails 3.1

### DIFF
--- a/lib/decent_exposure/active_record_strategy.rb
+++ b/lib/decent_exposure/active_record_strategy.rb
@@ -38,7 +38,7 @@ module DecentExposure
     end
 
     def collection_resource
-      return scope if scope.respond_to?(:each)
+      return scope if scope.is_a?(ActiveRecord::Relation)
       scope.send(scope_method)
     end
 


### PR DESCRIPTION
See issue #67; this fixes a related occurrence of the same problem under different circumstances.

Backstory: 6e913c3d introduced a fast path that returned a scope from `collection_resource` if the scope were enumerable. Under Rails 3.1, the `AssociationProxy` returned from a has_many association somehow gets converted to an Array, and thus `collection_resource` ends up returning an Array instead of a scope that can be chained upon. This means that when trying to build a child resource, we get errors like "undefined method new for Array".

Minimal example of the problem is at https://github.com/acumenbrands/decent_exposure_bug -- you can clone, bundle, and `bin/rspec` to see a failing test.

This commit adjusts the fast-path code to only return the scope if the scope is already a Relation. 

decent_exposure specs are green, and this fixes the issue in the aforementioned `decent_exposure_bug` repository.

Thanks!

:heart: Brad, and the Acumen Brands team
