### PR TITLE
Proxy object implementation of the default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,11 +302,11 @@ This block is evaluated and the memoized result is returned whenever you call
 
 If you don't want to go too far off the beaten path, the value of the default
 exposure can be easily obtained inside of your custom block. The block will
-receive an object that you can `call` to lazily evaluate the default
-decent_exposure logic. For example:
+receive a proxy object that you can use to lazily evaluate 
+the default decent_exposure logic. For example:
 
 ```ruby
-expose(:articles) {|default| default.call.limit(10) }
+expose(:articles) {|default| default.limit(10) }
 ```
 
 This allows you to customize your exposures, without having to redo all of

--- a/lib/decent_exposure/strategizer.rb
+++ b/lib/decent_exposure/strategizer.rb
@@ -34,10 +34,21 @@ module DecentExposure
 
   BlockStrategy = Struct.new(:block, :exposure_strategy) do
     def call(controller)
-      default = Proc.new do
-        exposure_strategy.call(controller)
-      end
+      default = ExposureProxy.new(exposure_strategy, controller)
       controller.instance_exec(default, &block)
+    end
+  end
+
+  class ExposureProxy
+    instance_methods.each { |m| undef_method m unless m =~ /(^__|^send$|^object_id$)/ }
+
+    def initialize(exposure, controller)
+      @exposure, @controller = exposure, controller
+    end
+
+    def method_missing(*args)
+      @target ||= @exposure.call(@controller)
+      @target.send(*args)
     end
   end
 end

--- a/spec/decent_exposure/strategizer_spec.rb
+++ b/spec/decent_exposure/strategizer_spec.rb
@@ -5,7 +5,7 @@ describe DecentExposure::Strategizer do
     subject { exposure.strategy }
 
     context "when a block is given" do
-      let(:block) { lambda {|default| "foo" } }
+      let(:block) { lambda { "foo" } }
       let(:exposure) { DecentExposure::Strategizer.new("foobar", &block) }
       it "saves the proc as the strategy" do
         subject.block.should == block
@@ -20,7 +20,7 @@ describe DecentExposure::Strategizer do
           exposure.stub(:exposure_strategy) { exposure_strategy }
         end
 
-        context "that doesn't get called" do
+        context "that doesn't get used" do
           let(:block) { lambda{|default| "foo" } }
 
           it "doesn't call the exposure_strategy" do
@@ -32,15 +32,15 @@ describe DecentExposure::Strategizer do
           end
         end
 
-        context "that does get called" do
-          let(:block) { lambda{|default| default.call } }
+        context "that does get used" do
+          let(:block) { lambda{|default| default.upcase } }
 
           it "calls the exposure strategy" do
-            exposure_strategy.should_receive(:call).with(controller)
+            exposure_strategy.should_receive(:call).with(controller).and_call_original
           end
 
           it "returns the default value" do
-            strategy.call(controller).should == "default"
+            strategy.call(controller).should == "DEFAULT"
           end
         end
 


### PR DESCRIPTION
This pull request references #78, but uses a proxy object to lazily evaluate the default decent exposure logic, instead of `call`. I like this better because it has the least amount of surprises, while still lazily evaluating the code. Specs are included.

``` ruby
expose(:articles) {|default| default.limit(10) }
```
