### PR TITLE
Fix for Mongoid-only projects

### DIFF
--- a/lib/decent_exposure/active_record_strategy.rb
+++ b/lib/decent_exposure/active_record_strategy.rb
@@ -38,7 +38,7 @@ module DecentExposure
     end
 
     def collection_resource
-      return scope if scope.is_a?(ActiveRecord::Relation)
+      return scope if (defined?(ActiveRecord) && scope.is_a?(ActiveRecord::Relation)) || scope.respond_to?(:each)
       scope.send(scope_method)
     end
 


### PR DESCRIPTION
The latest commit breaks Decent Exposure for Mongoid-only projects because ActiveRecord is not defined.
