### PR TITLE
Fix Travis error by removing Rubinius version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
   - "2.0.0"
   - "1.9.3"
   - jruby-19mode
-  - rbx-19mode
+  - rbx
 
 gemfile:
   - ".gemfiles/Gemfile.rails-3.2.x"
@@ -16,5 +16,5 @@ matrix:
       gemfile: ".gemfiles/Gemfile.rails-3.2.x"
     - rvm: jruby-18mode
       gemfile: ".gemfiles/Gemfile.rails-3.2.x"
-    - rvm: rbx-18mode
+    - rvm: rbx
       gemfile: ".gemfiles/Gemfile.rails-3.2.x"

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,8 @@ gemspec
 
 gem 'pry'
 gem 'rails', '~> 4.0.0'
+
+platforms :rbx do
+  gem 'racc'
+  gem 'rubysl'
+end


### PR DESCRIPTION
I've been annoyed with my erroring Travis builds, so I did a little research today and found this:
https://github.com/travis-ci/travis-ci/issues/1641

So, this should fix your rbx build too.
