### PR TITLE
Rails 4.1.0.beta1 Fix

### DIFF
--- a/lib/decent_exposure/expose.rb
+++ b/lib/decent_exposure/expose.rb
@@ -13,9 +13,7 @@ module DecentExposure
         end
         hide_action :_resources
 
-        def protected_instance_variables
-          ActionController::Base.protected_instance_variables + ["@_resources"]
-        end
+        protected_instance_variables << "@_resources"
       end
     end
 


### PR DESCRIPTION
In Edge Rails, `ActionController::Base.protected_instance_variables` is a Set rather than an Array (see https://github.com/rails/rails/commit/c8b566d54da278a8e675115bcf2e9590f75f5eb5), and so calling `#push` raises a NoMethodError. This tiny change uses the `#+` operator instead, which behaves as expected for Sets and Arrays.
