### PR TITLE
Fix 'wrong constant name' error (Rails 4.1.0beta1)

### DIFF
--- a/lib/decent_exposure/constant_resolver.rb
+++ b/lib/decent_exposure/constant_resolver.rb
@@ -26,7 +26,9 @@ module DecentExposure
 
     def namespace
       path = context.to_s
-      path[0...(path.rindex('::') || 0)].constantize
+      name = path[0...(path.rindex('::') || 0)]
+      return Object if name.blank?
+      name.constantize
     end
   end
 end


### PR DESCRIPTION
I keep having 'NameError: wrong constant name' wherever I use any kind of `expose` in my controllers in Rails 4.1 (was working great in 4.0).

So I digged a little and the reason is that:

``` rb
path # => "CarsController"
path[0...(path.rindex('::') || 0)] # => "" (empty string)
"".constantize # (rails 4.0) => Object 
"".constantize # (rails 4.1) => NameError: wrong constant name
```

Here is a small change that fixes that.
P.S. maintainers of `mongoid` gem had [similar problem](https://github.com/mongoid/mongoid/pull/3475).
