### PR TITLE
Allow method calls on the proxy object to take a block.

### DIFF
--- a/lib/decent_exposure/strategizer.rb
+++ b/lib/decent_exposure/strategizer.rb
@@ -46,9 +46,9 @@ module DecentExposure
       @exposure, @controller = exposure, controller
     end
 
-    def method_missing(*args)
+    def method_missing(*args, &blk)
       @target ||= @exposure.call(@controller)
-      @target.send(*args)
+      @target.send(*args, &blk)
     end
   end
 end

--- a/spec/decent_exposure/strategizer_spec.rb
+++ b/spec/decent_exposure/strategizer_spec.rb
@@ -44,6 +44,14 @@ describe DecentExposure::Strategizer do
           end
         end
 
+        context 'operates on proxy' do
+          let(:block) { lambda{|default| default } }
+
+          it 'proxies arguments and block' do
+            strategy.call(controller).gsub(/fault/) {|m| m.reverse}.should == 'detluaf'
+          end
+        end
+
         after do
           strategy.call(controller)
         end


### PR DESCRIPTION
If block returns the proxy object (maybe it just slightly tweaks that
object) and then code operating on that proxy object calls a method that
takes a block, the block is lost.

This passes the block onto the real object.