### PR TITLE
Remove hide_action calls

### DIFF
--- a/lib/decent_exposure/expose.rb
+++ b/lib/decent_exposure/expose.rb
@@ -11,6 +11,7 @@ module DecentExposure
         def _resources
           @_resources ||= {}
         end
+        private_class_method :_resources
 
         protected_instance_variables << "@_resources"
       end
@@ -53,10 +54,12 @@ module DecentExposure
         _resources[name] = exposure.call(self)
       end
       helper_method name
+      private name
 
       define_method("#{name}=") do |value|
         _resources[name] = value
       end
+      private "#{name}="
     end
   end
 end

--- a/lib/decent_exposure/expose.rb
+++ b/lib/decent_exposure/expose.rb
@@ -11,7 +11,6 @@ module DecentExposure
         def _resources
           @_resources ||= {}
         end
-        hide_action :_resources
 
         protected_instance_variables << "@_resources"
       end
@@ -54,12 +53,10 @@ module DecentExposure
         _resources[name] = exposure.call(self)
       end
       helper_method name
-      hide_action name
 
       define_method("#{name}=") do |value|
         _resources[name] = value
       end
-      hide_action "#{name}="
     end
   end
 end


### PR DESCRIPTION
This method has been removed in Rails 5, see
https://github.com/rails/rails/issues/18336