### PR TITLE
Removing ActiveSupport delegate in favor of ruby

### DIFF
--- a/lib/decent_exposure/active_record_strategy.rb
+++ b/lib/decent_exposure/active_record_strategy.rb
@@ -1,10 +1,11 @@
 require 'decent_exposure/strategy'
-require 'active_support/core_ext/module/delegation'
+require 'forwardable'
 
 module DecentExposure
   class ActiveRecordStrategy < Strategy
-    delegate :plural?, :parameter, :to => :inflector
-    delegate :get?, :delete?, :post?, :put?, :patch?, :to => :request
+    extend Forwardable
+    delegate [:plural?, :parameter] => :inflector
+    delegate [:get?, :delete?, :post?, :put?, :patch?] => :request
 
     def singular?
       !plural?

--- a/lib/decent_exposure/inflector.rb
+++ b/lib/decent_exposure/inflector.rb
@@ -1,9 +1,12 @@
 require 'active_support/inflector'
 require 'active_support/core_ext/string'
 require 'active_model/naming'
+require 'forwardable'
 
 module DecentExposure
   class Inflector
+    extend Forwardable
+
     attr_reader :original, :model
 
     def initialize(name, model)
@@ -21,7 +24,7 @@ module DecentExposure
                       end
     end
 
-    delegate :singular, :plural, :param_key, :to => :model_name
+    delegate [:singular, :plural, :param_key] => :model_name
     alias collection plural
 
     def parameter


### PR DESCRIPTION
Opting to use ruby's `Forwardable` instead of pulling in the ActiveSupport file to gain access to `delegate`.