### PR TITLE
Fix broken link to blog post in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,4 +496,4 @@ end
 ```
 
 
-[1]: http://blog.voxdolo.me/a-diatribe-on-maintaining-state.html
+[1]: http://stephencaudill.com/blog/2010/a-diatribe-on-maintaining-state.html


### PR DESCRIPTION
fix link to [A Diatribe on Maintaining State](http://stephencaudill.com/blog/2010/a-diatribe-on-maintaining-state.html)