### PR TITLE
Assign attributes when models are initialised

### DIFF
--- a/lib/decent_exposure/active_record_strategy.rb
+++ b/lib/decent_exposure/active_record_strategy.rb
@@ -55,19 +55,21 @@ module DecentExposure
       end
     end
 
-    def singular_resource
+    def singular_resource(attrs)
       if id
-        scope.send(finder, id)
+        scope.send(finder, id).tap do |resource|
+          resource.attributes = attrs if attrs
+        end
       else
-        scope.new
+        attrs ? scope.new(attrs) : scope.new
       end
     end
 
-    def resource
+    def resource(attrs = nil)
       if plural?
         collection_resource
       else
-        singular_resource
+        singular_resource(attrs)
       end
     end
 

--- a/lib/decent_exposure/strategies/assign_from_method.rb
+++ b/lib/decent_exposure/strategies/assign_from_method.rb
@@ -11,9 +11,7 @@ module DecentExposure
       end
 
       def resource
-        super.tap do |r|
-          r.attributes = attributes if assign_attributes?
-        end
+        assign_attributes? ? super(attributes) : super
       end
     end
   end

--- a/lib/decent_exposure/strategies/assign_from_params.rb
+++ b/lib/decent_exposure/strategies/assign_from_params.rb
@@ -15,9 +15,7 @@ module DecentExposure
       end
 
       def resource
-        r = super
-        r.attributes = attributes if assign_attributes?
-        r
+        assign_attributes? ? super(attributes) : super
       end
     end
   end

--- a/spec/decent_exposure/active_record_with_eager_attributes_strategy_spec.rb
+++ b/spec/decent_exposure/active_record_with_eager_attributes_strategy_spec.rb
@@ -86,8 +86,7 @@ describe DecentExposure::ActiveRecordWithEagerAttributesStrategy do
       let(:plural) { false }
 
       it "sends a empty hash to attributes=" do
-        model.should_receive(:new).and_return(instance)
-        instance.should_receive(:attributes=).with({})
+        model.should_receive(:new).with({}).and_return(instance)
         should == instance
       end
     end
@@ -99,8 +98,7 @@ describe DecentExposure::ActiveRecordWithEagerAttributesStrategy do
       let(:plural) { false }
       let(:instance) { double }
       it "it builds a new instance of the resource" do
-        model.should_receive(:new).and_return(instance)
-        instance.should_receive(:attributes=)
+        model.should_receive(:new).with({ "name" => "Timmy" }).and_return(instance)
         should == instance
       end
     end


### PR DESCRIPTION
Instead of assigning attributes after models have been initialised, we
can supply the attributes to the initialisation routine.

A couple of tests have been updated to reflect the change.