### PR TITLE
Intercept `inspect` on collection resources

### DIFF
--- a/lib/decent_exposure/active_record_strategy.rb
+++ b/lib/decent_exposure/active_record_strategy.rb
@@ -1,4 +1,5 @@
 require 'decent_exposure/strategy'
+require 'decent_exposure/resource_wrapper'
 require 'active_support/core_ext/module/delegation'
 
 module DecentExposure
@@ -44,7 +45,8 @@ module DecentExposure
 
     def collection_resource
       return scope if scope.respond_to?(:proxy_association) || scope.respond_to?(:each)
-      scope.send(scope_method)
+      res = scope.send(scope_method)
+      ResourceWrapper.new(res)
     end
 
     def id

--- a/lib/decent_exposure/resource_wrapper.rb
+++ b/lib/decent_exposure/resource_wrapper.rb
@@ -1,0 +1,7 @@
+module DecentExposure
+  class ResourceWrapper < ::SimpleDelegator
+    def inspect
+      "#<ActiveRecord::Relation>"
+    end
+  end
+end

--- a/spec/decent_exposure/active_record_strategy_spec.rb
+++ b/spec/decent_exposure/active_record_strategy_spec.rb
@@ -192,6 +192,23 @@ RSpec.describe DecentExposure::ActiveRecordStrategy do
         end
 
       end
+
+      context 'and a call to inspect' do
+        let(:association_scope) { double('AssociationScope') }
+        let(:association) { double("Association", scoped: association_scope, all: association_scope) }
+        let(:collection) { double("Collection", models: association) }
+        let(:strategy) do
+          DecentExposure::ActiveRecordStrategy.new(controller, inflector, ancestor: :ancestor_collection)
+        end
+
+        before do
+          allow(controller).to receive(:ancestor_collection).and_return(collection)
+        end
+
+        it 'intercepts call to inspect' do
+          expect(strategy.collection_resource.inspect).to eq "#<ActiveRecord::Relation>"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Calling `inspect` on Active Record collections fires up a sql query that
reads the entire table. `NameError` exceptions call inspect on all local
controller instance variables, which in turn can cause application to
hang.

This has been reported in Rails:
https://github.com/rails/rails/issues/1525

Closes #127