### PR TITLE
 [Rails 5] Updates test suite and provides compatibility with rails5.0.0beta3

### DIFF
--- a/.gemfiles/Gemfile.rails-5.0.x
+++ b/.gemfiles/Gemfile.rails-5.0.x
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gemspec :path => '..'
+
+gem 'rails', github: 'rails/rails'

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,7 @@ matrix:
       gemfile: ".gemfiles/Gemfile.rails-5.0.x"
     - rvm: 2.1.0
       gemfile: ".gemfiles/Gemfile.rails-5.0.x"
+    - rvm: 2.3.0
+      gemfile: ".gemfiles/Gemfile.rails-4.0.x"
+    - rvm: 2.3.0
+      gemfile: ".gemfiles/Gemfile.rails-3.2.x"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,10 @@ gemfile:
   - ".gemfiles/Gemfile.rails-3.2.x"
   - ".gemfiles/Gemfile.rails-4.0.x"
   - ".gemfiles/Gemfile.rails-5.0.x"
+
+matrix:
+  exclude:
+    - rvm: 2.0.0
+      gemfile: ".gemfiles/Gemfile.rails-5.0.x"
+    - rvm: 2.1.0
+      gemfile: ".gemfiles/Gemfile.rails-5.0.x"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: ruby
 
 rvm:
+  - "2.3.0"
   - "2.1.0"
   - "2.0.0"
 
 gemfile:
   - ".gemfiles/Gemfile.rails-3.2.x"
   - ".gemfiles/Gemfile.rails-4.0.x"
+  - ".gemfiles/Gemfile.rails-5.0.x"

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem 'pry'
-gem 'rails', '~> 4.0.0'
+gem 'rails', github: 'rails/rails'
 
 platforms :rbx do
   gem 'racc'

--- a/decent_exposure.gemspec
+++ b/decent_exposure.gemspec
@@ -29,8 +29,8 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.require_paths = ["lib"]
 
-  s.add_development_dependency 'rspec', '~> 3'
-  s.add_development_dependency 'rspec-rails', '~> 3'
+  
+  s.add_development_dependency 'rspec-rails', '~> 3.5.0.beta1'
   s.add_development_dependency 'actionpack', '>= 3.1.0'
   s.add_development_dependency 'activesupport', '>= 3.1.0'
 end

--- a/lib/decent_exposure/expose.rb
+++ b/lib/decent_exposure/expose.rb
@@ -1,6 +1,5 @@
 require 'decent_exposure/strategizer'
 require 'decent_exposure/configuration'
-require 'pry'
 
 module DecentExposure
   module Expose

--- a/lib/decent_exposure/expose.rb
+++ b/lib/decent_exposure/expose.rb
@@ -1,6 +1,6 @@
 require 'decent_exposure/strategizer'
 require 'decent_exposure/configuration'
-
+require 'pry'
 module DecentExposure
   module Expose
     def self.extended(base)
@@ -12,7 +12,12 @@ module DecentExposure
           @_resources ||= {}
         end
 
-        self::PROTECTED_IVARS << :@_resources
+        #backwards compatibility for rails 4.0.x
+        if self.const_defined? "PROTECTED_IVARS"
+          self::PROTECTED_IVARS << :@_resources
+        else
+          protected_instance_variables << "@_resources"
+        end
       end
     end
 

--- a/lib/decent_exposure/expose.rb
+++ b/lib/decent_exposure/expose.rb
@@ -1,5 +1,6 @@
 require 'decent_exposure/strategizer'
 require 'decent_exposure/configuration'
+require 'pry'
 
 module DecentExposure
   module Expose
@@ -12,7 +13,7 @@ module DecentExposure
           @_resources ||= {}
         end
 
-        protected_instance_variables << "@_resources"
+        self::PROTECTED_IVARS << :@_resources
       end
     end
 

--- a/lib/decent_exposure/expose.rb
+++ b/lib/decent_exposure/expose.rb
@@ -1,6 +1,6 @@
 require 'decent_exposure/strategizer'
 require 'decent_exposure/configuration'
-require 'pry'
+
 module DecentExposure
   module Expose
     def self.extended(base)

--- a/spec/decent_exposure/expose_spec.rb
+++ b/spec/decent_exposure/expose_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe DecentExposure::Expose do
     end
 
     it 'blacklists the @_resources instance variable' do
-      expect(controller.protected_instance_variables).to include("@_resources")
+      expect(controller._protected_ivars).to include(:@_resources)
     end
   end
 

--- a/spec/decent_exposure/expose_spec.rb
+++ b/spec/decent_exposure/expose_spec.rb
@@ -27,7 +27,12 @@ RSpec.describe DecentExposure::Expose do
     end
 
     it 'blacklists the @_resources instance variable' do
-      expect(controller._protected_ivars).to include(:@_resources)
+      #Backwards compatibility for rails 4.0.x
+      if Rails.rails5?
+        expect(controller._protected_ivars).to include(:@_resources)
+      else
+        expect(controller.protected_instance_variables).to include("@_resources")
+      end
     end
   end
 

--- a/spec/fixtures/controllers.rb
+++ b/spec/fixtures/controllers.rb
@@ -95,16 +95,16 @@ class BirdController < ActionController::Base
   expose(:custom_from_config, :config => :custom)
 
   def show
-    render :plain => "Foo"
+    render (Rails.rails5? ? :plain : :text) => "Foo"
   end
 
   def index
     self.bird = Parrot.new(:beak => "custom")
-    render :plain => "index"
+    render (Rails.rails5? ? :plain : :text) => "index"
   end
 
   def new
-    render :plain => "new"
+    render (Rails.rails5? ? :plain : :text) => "new"
   end
 end
 
@@ -129,7 +129,7 @@ class StrongParametersController < ActionController::Base
   expose(:unassignable, :model => Parrot)
 
   def show
-    render :plain => "show"
+    render (Rails.rails5? ? :plain : :text) => "show"
   end
 
   def assignable_attributes
@@ -151,7 +151,7 @@ module ::Namespace
   class ModelController < ActionController::Base
     include Rails.application.routes.url_helpers
     expose(:model)
-    def show; render :plain => ""; end
+    def show; render (Rails.rails5? ? :plain : :text) => ""; end
   end
 end
 
@@ -170,6 +170,6 @@ class TaxonomiesController < ActionController::Base
   expose(:owl, :config => :owl_find, :model => :organism)
 
   def show
-    render :plain => 'show'
+    render (Rails.rails5? ? :plain : :text) => 'show'
   end
 end

--- a/spec/fixtures/controllers.rb
+++ b/spec/fixtures/controllers.rb
@@ -95,16 +95,16 @@ class BirdController < ActionController::Base
   expose(:custom_from_config, :config => :custom)
 
   def show
-    render :text => "Foo"
+    render :plain => "Foo"
   end
 
   def index
     self.bird = Parrot.new(:beak => "custom")
-    render :text => "index"
+    render :plain => "index"
   end
 
   def new
-    render :text => "new"
+    render :plain => "new"
   end
 end
 
@@ -129,7 +129,7 @@ class StrongParametersController < ActionController::Base
   expose(:unassignable, :model => Parrot)
 
   def show
-    render :text => "show"
+    render :plain => "show"
   end
 
   def assignable_attributes
@@ -151,7 +151,7 @@ module ::Namespace
   class ModelController < ActionController::Base
     include Rails.application.routes.url_helpers
     expose(:model)
-    def show; render :text => ""; end
+    def show; render :plain => ""; end
   end
 end
 
@@ -170,6 +170,6 @@ class TaxonomiesController < ActionController::Base
   expose(:owl, :config => :owl_find, :model => :organism)
 
   def show
-    render :text => 'show'
+    render :plain => 'show'
   end
 end

--- a/spec/fixtures/fake_rails_application.rb
+++ b/spec/fixtures/fake_rails_application.rb
@@ -6,6 +6,10 @@ require 'active_model'
 require 'rails'
 require 'decent_exposure'
 
+# Uncomment this if you are working on rails 5 fixes
+# It will mute deprecation warnings (we need to refactor rails_integration_spec.rb to get rid of them)
+# ActiveSupport::Deprecation.silenced = true
+
 # Boilerplate
 module Rails
   class App

--- a/spec/fixtures/fake_rails_application.rb
+++ b/spec/fixtures/fake_rails_application.rb
@@ -26,6 +26,11 @@ module Rails
       @routes
     end
   end
+
+  def self.rails5?
+    Rails.version.start_with?('5')
+  end
+
   def self.application
     @app ||= App.new
   end

--- a/spec/fixtures/fake_rails_application.rb
+++ b/spec/fixtures/fake_rails_application.rb
@@ -2,7 +2,7 @@ require 'active_support/all'
 require 'action_controller'
 require 'action_dispatch'
 require 'active_model'
-require 'active_record'
+
 require 'rails'
 require 'decent_exposure'
 

--- a/spec/rails_integration_spec.rb
+++ b/spec/rails_integration_spec.rb
@@ -11,12 +11,12 @@ RSpec.describe BirdController, type: :controller do
 
   describe "default model strategy" do
     it "finds the instance with params[:id]" do
-      get :show, params: { id: "something" }
+      get :show, { id: "something" }
       expect(controller.parrot).to be_a(Parrot)
     end
 
     it "finds the instance with params[:model_id]" do
-      get :show, params: {parrot_id: "something"}
+      get :show, {parrot_id: "something"}
       expect(controller.parrot).to be_a(Parrot)
     end
 
@@ -27,26 +27,26 @@ RSpec.describe BirdController, type: :controller do
 
     context "with a named model" do
       it "finds an instance" do
-        get :show, params: { id: "something" }
+        get :show, { id: "something" }
         expect(controller.albert).to be_a(Parrot)
       end
     end
 
     context "with a namespaced model class" do
       it "finds an instance" do
-        get :show, params: { id: "something" }
+        get :show, { id: "something" }
         expect(controller.bernard.beak).to eq("admin")
       end
 
       it "assigns based on model's param key" do
-        post :show, params: { admin_parrot: { beak: "bent" } }
+        post :show, { admin_parrot: { beak: "bent" } }
         expect(controller.bernard.beak).to eq("bent")
       end
     end
   end
 
   describe "attribute setting" do
-    let(:request) { [:show, params: { id: 2, parrot: { beak: "droopy" } }] }
+    let(:request) { [:show, { id: 2, parrot: { beak: "droopy" } }] }
     it "attributes are set for post requests" do
       post *request
       expect(controller.parrot.beak).to eq("droopy")
@@ -64,7 +64,7 @@ RSpec.describe BirdController, type: :controller do
 
     context "with no finding parameter" do
       it "builds a new model instance with the provided attributes" do
-        get :new, params: { parrot: { beak: "smallish" } }
+        get :new, { parrot: { beak: "smallish" } }
         expect(controller.parrot.beak).to eq("smallish")
       end
 
@@ -123,7 +123,7 @@ RSpec.describe DuckController, type: :controller do
 
   describe "collection scope" do
     it "scopes a resource to its collection exposure" do
-      get :show, params: { id: "burp" }
+      get :show, { id: "burp" }
       expect(controller.duck.id).to eq("burp")
     end
   end
@@ -142,7 +142,7 @@ end
 RSpec.describe StrongParametersController, type: :controller do
   describe "attribute setting" do
     context "with an 'attributes' option set" do
-      let(:request) { [:show, params: { id: 2, assignable: { beak: "droopy" } }] }
+      let(:request) { [:show, { id: 2, assignable: { beak: "droopy" } }] }
       it "assigns attributes for post requests, using the method from 'attributes'" do
         post *request
         expect(controller.assignable.beak).to eq("droopy")
@@ -165,7 +165,7 @@ RSpec.describe StrongParametersController, type: :controller do
     end
 
     context "with no 'attributes' option set" do
-      let(:request) { [:show, params: { id: 2, unassignable: { beak: "droopy" } }] }
+      let(:request) { [:show, { id: 2, unassignable: { beak: "droopy" } }] }
       it "does not assign attributes" do
         post *request
         expect(controller.assignable.beak).to_not eq("droopy")
@@ -177,14 +177,14 @@ end
 RSpec.describe TaxonomiesController, type: :controller do
   describe 'default configration' do
     it 'uses the configured finder' do
-      get :show, params: { id: "something" }
+      get :show, { id: "something" }
       expect(controller.organism).to be_a(Organism)
     end
   end
 
   describe 'named configration' do
     it "uses the named configuration's options" do
-      get :show, params: { id: "something" }
+      get :show, { id: "something" }
       expect(controller.owl.species).to eq("Striginae")
     end
   end
@@ -192,7 +192,7 @@ end
 
 RSpec.describe Namespace::ModelController, type: :controller do
   it "finds the instance of the namespaced model" do
-    get :show, params: { id: "foo" }
+    get :show, { id: "foo" }
     expect(controller.model.name).to eq("inner")
   end
 end

--- a/spec/rails_integration_spec.rb
+++ b/spec/rails_integration_spec.rb
@@ -11,12 +11,12 @@ RSpec.describe BirdController, type: :controller do
 
   describe "default model strategy" do
     it "finds the instance with params[:id]" do
-      get :show, id: "something"
+      get :show, params: { id: "something" }
       expect(controller.parrot).to be_a(Parrot)
     end
 
     it "finds the instance with params[:model_id]" do
-      get :show, parrot_id: "something"
+      get :show, params: {parrot_id: "something"}
       expect(controller.parrot).to be_a(Parrot)
     end
 
@@ -27,26 +27,26 @@ RSpec.describe BirdController, type: :controller do
 
     context "with a named model" do
       it "finds an instance" do
-        get :show, id: "something"
+        get :show, params: { id: "something" }
         expect(controller.albert).to be_a(Parrot)
       end
     end
 
     context "with a namespaced model class" do
       it "finds an instance" do
-        get :show, id: "something"
+        get :show, params: { id: "something" }
         expect(controller.bernard.beak).to eq("admin")
       end
 
       it "assigns based on model's param key" do
-        post :show, admin_parrot: { beak: "bent" }
+        post :show, params: { admin_parrot: { beak: "bent" } }
         expect(controller.bernard.beak).to eq("bent")
       end
     end
   end
 
   describe "attribute setting" do
-    let(:request) { [:show, { id: 2, parrot: { beak: "droopy" } }] }
+    let(:request) { [:show, params: { id: 2, parrot: { beak: "droopy" } }] }
     it "attributes are set for post requests" do
       post *request
       expect(controller.parrot.beak).to eq("droopy")
@@ -64,7 +64,7 @@ RSpec.describe BirdController, type: :controller do
 
     context "with no finding parameter" do
       it "builds a new model instance with the provided attributes" do
-        get :new, parrot: { beak: "smallish" }
+        get :new, params: { parrot: { beak: "smallish" } }
         expect(controller.parrot.beak).to eq("smallish")
       end
 
@@ -123,7 +123,7 @@ RSpec.describe DuckController, type: :controller do
 
   describe "collection scope" do
     it "scopes a resource to its collection exposure" do
-      get :show, id: "burp"
+      get :show, params: { id: "burp" }
       expect(controller.duck.id).to eq("burp")
     end
   end
@@ -142,7 +142,7 @@ end
 RSpec.describe StrongParametersController, type: :controller do
   describe "attribute setting" do
     context "with an 'attributes' option set" do
-      let(:request) { [:show, { id: 2, assignable: { beak: "droopy" } }] }
+      let(:request) { [:show, params: { id: 2, assignable: { beak: "droopy" } }] }
       it "assigns attributes for post requests, using the method from 'attributes'" do
         post *request
         expect(controller.assignable.beak).to eq("droopy")
@@ -165,7 +165,7 @@ RSpec.describe StrongParametersController, type: :controller do
     end
 
     context "with no 'attributes' option set" do
-      let(:request) { [:show, { id: 2, unassignable: { beak: "droopy" } }] }
+      let(:request) { [:show, params: { id: 2, unassignable: { beak: "droopy" } }] }
       it "does not assign attributes" do
         post *request
         expect(controller.assignable.beak).to_not eq("droopy")
@@ -177,14 +177,14 @@ end
 RSpec.describe TaxonomiesController, type: :controller do
   describe 'default configration' do
     it 'uses the configured finder' do
-      get :show, id: "something"
+      get :show, params: { id: "something" }
       expect(controller.organism).to be_a(Organism)
     end
   end
 
   describe 'named configration' do
     it "uses the named configuration's options" do
-      get :show, id: "something"
+      get :show, params: { id: "something" }
       expect(controller.owl.species).to eq("Striginae")
     end
   end
@@ -192,7 +192,7 @@ end
 
 RSpec.describe Namespace::ModelController, type: :controller do
   it "finds the instance of the namespaced model" do
-    get :show, id: "foo"
+    get :show, params: { id: "foo" }
     expect(controller.model.name).to eq("inner")
   end
 end


### PR DESCRIPTION
References #139 

Fixes rails 5 issue with deprecated/removed methods from ActionPack.
     * protected_instance_variables method no longer exists on rails 5 ( https://github.com/rails/rails/commit/74b23b9e4be99f1735812b6e58e800f987c3a8a2 ). This commit uses the new class constant where these instance variables are listed.
     * updates the spec examples to use the'_protected_ivars' method introduced on this commit https://github.com/rails/rails/commit/267e5c84f96b96f8eac9f4a3dcdce5bc1b82541c which is the only method that remains on rails codebase now
     * Updates test suite to rails5.0.0beta3 and rspec3.5.0beta to replicate rails5 compatibility and fix the issue properly for upcoming versions.
     * ~~Takes care of deprecations warning related with rails 5 and ActionController::TestCase HTTP request methods using keyword arguments.~~ (Removed this to keep backward compatibility)
     * Removes ActiveRecord from the test suite to avoid db connections (The 'fake_rails_application.rb' were not using it anyways)

**This PR is backwards compatible with rails 4.0.x, but we may need to refactor `rails_integration_spec.rb` to use the new keywords arguments for params of HTTP requests. (we may add both styles using the method that I've introduced in this PR `Rails.rails5?`)**