### PR TITLE
Rails4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ DecentExposure `3.0` is a major change from `< 3.0`. If you are using `rails <= 
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'decent_exposure'
+gem 'decent_exposure', '3.0.0.beta1'
 ```
 
 And then execute:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 
 ### Notice
 
-DecentExposure `3.0` is a major change from `< 3.0`. If you are using `rails <= 4.2.x` please look at `decent_exposure < 3.0`.
+DecentExposure `3.0` is a major change from `< 3.0`.
+
+Version `3.0` will support Rails 4 and 5.
 
 **Be aware... mild API changes ahead.**
 

--- a/decent_exposure.gemspec
+++ b/decent_exposure.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = "~> 2.0"
 
-  spec.add_dependency "railties",      "~> 5.x"
-  spec.add_dependency "activesupport", "~> 5.x"
+  spec.add_dependency "activesupport", ">= 4.0"
+  spec.add_development_dependency "railties", ">= 4.0"
   spec.add_development_dependency "rspec-rails", "~> 3.0"
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -9,17 +9,17 @@ describe BirdsController, type: :controller do
     after{ expect(controller.bird).to eq(mockingbird) }
 
     it "finds model by id" do
-      get :show, params: { id: "mockingbird" }
+      get :show, { id: "mockingbird" }
     end
 
     it "finds model by bird_id" do
-      get :show, params: { bird_id: "mockingbird" }
+      get :show, { bird_id: "mockingbird" }
     end
   end
 
   it "builds bird if id is not provided" do
     bird = double("Bird")
-    expect(Bird).to receive(:new).and_return(bird)
+    expect(Bird).to receive(:new).with({}).and_return(bird)
     get :show
     expect(controller.bird).to eq(bird)
   end


### PR DESCRIPTION
Prepare decent_exposure to work with rails4

- [x] remove unucessary `railties`
- [x] let `activesupport` version to `>= 4.0`