### PR TITLE
Include decent_exposure to Mailers and its views

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,32 @@ expose :thing, with: [:cool_find, :cool_build]
 expose :another_thing, with: :cool_build
 ```
 
+## Rails Mailers
+
+Mailers and Controllers use the save decent_exposure dsl.
+
+### Example Mailer
+
+```ruby
+class PostMailer < ApplicationMailer
+  attr_accessor :post_id
+
+  expose(:posts, -> { Post.last(10) })
+  expose(:post, id: -> { post_id })
+
+  def top_posts
+    @greeting = "Top Posts"
+    mail to: "to@example.org"
+  end
+
+  def featured_post(post_id = nil)
+    self.post_id = post_id
+    @greeting = "Featured Post"
+    mail to: "to@example.org"
+  end
+end
+```
+
 ## Rails Scaffold Templates
 
 If you want to generate rails scaffold templates prepared for `decent_exposure` run:

--- a/lib/decent_exposure.rb
+++ b/lib/decent_exposure.rb
@@ -13,4 +13,8 @@ module DecentExposure
   ActiveSupport.on_load :action_controller do
     include Controller
   end
+
+  ActiveSupport.on_load :action_mailer do
+    include Controller
+  end
 end


### PR DESCRIPTION
- [x] Include decent_exposure to Mailers and its views

You'll need to set in the mailer instance your params. Check this:

```ruby
class PostMailer < ApplicationMailer
  attr_accessor :post_id

  expose :posts, -> { Post.last 5 }
  expose(:post, id: -> { post_id })

  def best_posts_ever(post_id = nil)
    self.post_id = post_id
    @greeting = "Hi"

    mail to: "to@example.org"
  end
end
```

```html
<h1>Post#best_posts_ever</h1>

<p>
  <%= @greeting %>, find me in app/views/post_mailer/best_posts_ever.html.erb
  Single Post = <%= post.inspect %>
  Post List = <%= posts.map(&:inspect) %>
</p>
```

closes #150