### PR TITLE
Raise ArgumentError when expose overwrite helpers

### DIFF
--- a/lib/decent_exposure/attribute.rb
+++ b/lib/decent_exposure/attribute.rb
@@ -41,13 +41,6 @@ module DecentExposure
     def expose!(klass)
       attribute = self
 
-      # Check if attribute getter is overwriting an existing helper
-      getter = attribute.getter_method_name
-      if ActionView::Helpers.instance_methods.include?(getter)
-        message = "Helper method '#{getter}' is already defined"
-        raise ArgumentError, message
-      end
-
       klass.instance_eval do
         define_method attribute.getter_method_name do
           Context.new(self, attribute).get

--- a/lib/decent_exposure/attribute.rb
+++ b/lib/decent_exposure/attribute.rb
@@ -41,6 +41,13 @@ module DecentExposure
     def expose!(klass)
       attribute = self
 
+      # Check if attribute getter is overwriting an existing helper
+      getter = attribute.getter_method_name
+      if ActionView::Helpers.instance_methods.include?(getter)
+        message = "Helper method '#{getter}' is already defined"
+        raise ArgumentError, message
+      end
+
       klass.instance_eval do
         define_method attribute.getter_method_name do
           Context.new(self, attribute).get

--- a/lib/decent_exposure/exposure.rb
+++ b/lib/decent_exposure/exposure.rb
@@ -35,6 +35,12 @@ module DecentExposure
     #
     # Returns a normalized options Hash.
     def initialize(controller, name, fetch_block=nil, **options, &block)
+      # Check if the Exposure getter would overwrite an existing helper
+      if ActionView::Helpers.instance_methods.include?(name.to_sym)
+        message = "Helper method '#{name}' is already defined"
+        raise ArgumentError, message
+      end
+
       @controller = controller
       @options = options.with_indifferent_access.merge(name: name)
 

--- a/spec/decent_exposure/controller_spec.rb
+++ b/spec/decent_exposure/controller_spec.rb
@@ -377,7 +377,7 @@ RSpec.describe DecentExposure::Controller do
     end
   end
 
-  context "overwrite existing helper" do
+  context "expose overwrite existing helper" do
     let(:controller_klass) do
       Class.new(BaseController) do
         include ActionView::Helpers::TagHelper
@@ -389,7 +389,7 @@ RSpec.describe DecentExposure::Controller do
 
     it "throws an error when overwriting an existing helper" do
       expect(controller).to respond_to(:tag)
-      expect(controller.tag.p("test")).to eq("<p>test</p>")
+      expect(controller.tag("br")).to eq("<br />")
 
       expect { expose :tag }.to raise_error(ArgumentError, "Helper method 'tag' is already defined")
     end

--- a/spec/decent_exposure/controller_spec.rb
+++ b/spec/decent_exposure/controller_spec.rb
@@ -376,4 +376,22 @@ RSpec.describe DecentExposure::Controller do
       expect(controller.thing).to eq(decorated_thing)
     end
   end
+
+  context "overwrite existing helper" do
+    let(:controller_klass) do
+      Class.new(BaseController) do
+        include ActionView::Helpers::TagHelper
+        include DecentExposure::Controller
+      end
+    end
+
+    let(:controller) { controller_klass.new }
+
+    it "throws an error when overwriting an existing helper" do
+      expect(controller).to respond_to(:tag)
+      expect(controller.tag.p("test")).to eq("<p>test</p>")
+
+      expect { expose :tag }.to raise_error(ArgumentError, "Helper method 'tag' is already defined")
+    end
+  end
 end


### PR DESCRIPTION
Raise `ArgumentError` when exposing an attribute that will overwrite a helper defined by `ActionView`.

This PR will prevent `expose :tag` from silently overwriting the `tag` helper defined by `ActionView::Helpers::TagHelper `.

See https://github.com/hashrocket/decent_exposure/issues/180.