### PR TITLE
Initial take on shallow_child and shallow_parent

### DIFF
--- a/lib/decent_exposure/controller.rb
+++ b/lib/decent_exposure/controller.rb
@@ -3,8 +3,12 @@ module DecentExposure
     extend ActiveSupport::Concern
 
     included do
-      class_attribute :exposure_configuration,
+      class_attribute :exposure_configuration, :exposures,
         instance_accessor: false, instance_predicate: false
+    end
+
+    def get_exposure(name)
+      instance_exec &self.class.exposures[name]
     end
 
     module ClassMethods
@@ -47,6 +51,11 @@ module DecentExposure
       def exposure_config(name, options)
         store = self.exposure_configuration ||= {}
         self.exposure_configuration = store.merge(name => options)
+      end
+
+      def add_exposure(name, exposure)
+        store = self.exposures ||= {}
+        self.exposures = store.merge(name => exposure)
       end
     end
   end


### PR DESCRIPTION
* Adds the controller method `exposures` in order to register exposure flows for later use. We specifically need the `shallow_parent_exposure` to detect if the parents param ids exist or not.
* Adds the `:shallow_parent` and `:shallow_child` options. With shallow routes, parents need to be found via their shallow child when the child id params exist (edit, update, destroy) - similarly, children need to be scoped by their shallow parent when the parent id params exist (index, show, new, create).

No tests yet as I don't want to waste time on them if you don't like this as a feature.

Closes #188 