### PR TITLE
Create instance and apply params separately

### DIFF
--- a/lib/decent_exposure/behavior.rb
+++ b/lib/decent_exposure/behavior.rb
@@ -61,8 +61,12 @@ module DecentExposure
     #
     # Returns the new object.
     def build(params, scope)
-      instance = scope.new
-      instance.attributes = params
+      if scope.is_a?(ActiveRecord::Relation) || scope.is_a?(Class) && scope < ActiveRecord::Base
+        instance = scope.new
+        instance.attributes = params
+      else
+        instance = scope.new params
+      end
 
       instance
     end

--- a/lib/decent_exposure/behavior.rb
+++ b/lib/decent_exposure/behavior.rb
@@ -61,7 +61,10 @@ module DecentExposure
     #
     # Returns the new object.
     def build(params, scope)
-      scope.new(params)
+      instance = scope.new
+      instance.attributes = params
+
+      instance
     end
 
     # Public: Returns a decorated object. This method is designed to be

--- a/spec/decent_exposure/controller_spec.rb
+++ b/spec/decent_exposure/controller_spec.rb
@@ -175,7 +175,8 @@ RSpec.describe DecentExposure::Controller do
       context "params method is not available" do
         it "builds a new instance with empty hash" do
           expose :thing
-          expect(Thing).to receive(:new).with({}).and_return(thing)
+          expect(Thing).to receive(:new).and_return(thing)
+          expect(thing).to receive(:attributes=).with({})
         end
       end
 
@@ -184,27 +185,31 @@ RSpec.describe DecentExposure::Controller do
           expose :thing
           expect(request).to receive(:get?).and_return(true)
           expect(controller).not_to receive(:thing_params)
-          expect(Thing).to receive(:new).with({}).and_return(thing)
+          expect(Thing).to receive(:new).and_return(thing)
+          expect(thing).to receive(:attributes=).with({})
         end
 
         it "uses params method on non-get request" do
           expose :thing
           expect(request).to receive(:get?).and_return(false)
-          expect(Thing).to receive(:new).with(foo: :bar).and_return(thing)
+          expect(Thing).to receive(:new).and_return(thing)
+          expect(thing).to receive(:attributes=).with(foo: :bar)
           expect(controller).to receive(:thing_params).and_return(foo: :bar)
         end
 
         it "can use custom params method name" do
           expose :thing, build_params: :custom_params_method_name
           expect(request).to receive(:get?).and_return(false)
-          expect(Thing).to receive(:new).with(foo: :bar).and_return(thing)
+          expect(Thing).to receive(:new).and_return(thing)
+          expect(thing).to receive(:attributes=).with(foo: :bar)
           expect(controller).to receive(:custom_params_method_name).and_return(foo: :bar)
         end
 
         it "can use custom build params" do
           expose :thing, build_params: ->{ foobar }
           expect(controller).to receive(:foobar).and_return(42)
-          expect(Thing).to receive(:new).with(42).and_return(thing)
+          expect(Thing).to receive(:new).and_return(thing)
+          expect(thing).to receive(:attributes=).with(42)
         end
       end
     end
@@ -260,6 +265,7 @@ RSpec.describe DecentExposure::Controller do
     context "build/find" do
       let(:current_user){ double("User") }
       let(:scope){ double("Scope") }
+      let(:thing){ double("Thing") }
 
       before do
         expect(controller).to receive(:current_user).and_return(current_user)
@@ -267,22 +273,28 @@ RSpec.describe DecentExposure::Controller do
         expose :thing, parent: :current_user
       end
 
-      after{ expect(controller.thing).to eq(42) }
+      after{ expect(controller.thing).to eq(thing) }
 
       it "sets the scope to belong to parent defined by controller method" do
-        expect(scope).to receive(:new).with({}).and_return(42)
+        expect(scope).to receive(:new).and_return(thing)
+        expect(thing).to receive(:attributes=).with({})
       end
 
       it "scopes the find to proper scope" do
         controller.params.merge! thing_id: 10
-        expect(scope).to receive(:find).with(10).and_return(42)
+        expect(scope).to receive(:find).with(10).and_return(thing)
       end
     end
   end
 
   context "override model" do
     let(:different_thing){ double("DifferentThing") }
-    before{ expect(DifferentThing).to receive(:new).with({}).and_return(different_thing) }
+
+    before do
+      expect(DifferentThing).to receive(:new).and_return(different_thing)
+      expect(different_thing).to receive(:attributes=).with({})
+    end
+
     after{ expect(controller.thing).to eq(different_thing) }
 
     it "allows overriding model class with proc" do
@@ -305,17 +317,21 @@ RSpec.describe DecentExposure::Controller do
   context "override scope" do
     it "allows overriding scope with proc" do
       scope = double("Scope")
+      thing = double("Thing")
       expose :thing, scope: ->{ scope }
-      expect(scope).to receive(:new).and_return(42)
-      expect(controller.thing).to eq(42)
+      expect(scope).to receive(:new).and_return(thing)
+      expect(thing).to receive(:attributes=).with({})
+      expect(controller.thing).to eq(thing)
     end
 
     it "allows overriding model scope using symbol" do
       scope = double("Scope")
+      thing = double("Thing")
       expect(Thing).to receive(:custom_scope).and_return(scope)
-      expect(scope).to receive(:new).and_return(42)
+      expect(scope).to receive(:new).and_return(thing)
+      expect(thing).to receive(:attributes=).with({})
       expose :thing, scope: :custom_scope
-      expect(controller.thing).to eq(42)
+      expect(controller.thing).to eq(thing)
     end
   end
 
@@ -345,7 +361,8 @@ RSpec.describe DecentExposure::Controller do
     it "allows specify decorator" do
       expose :thing, decorate: ->(thing){ decorate(thing) }
       thing = double("Thing")
-      expect(Thing).to receive(:new).with({}).and_return(thing)
+      expect(Thing).to receive(:new).and_return(thing)
+      expect(thing).to receive(:attributes=).with({})
       expect(controller).to receive(:decorate).with(thing)
       controller.thing
     end

--- a/spec/decent_exposure/controller_spec.rb
+++ b/spec/decent_exposure/controller_spec.rb
@@ -175,8 +175,7 @@ RSpec.describe DecentExposure::Controller do
       context "params method is not available" do
         it "builds a new instance with empty hash" do
           expose :thing
-          expect(Thing).to receive(:new).and_return(thing)
-          expect(thing).to receive(:attributes=).with({})
+          expect(Thing).to receive(:new).with({}).and_return(thing)
         end
       end
 
@@ -185,31 +184,27 @@ RSpec.describe DecentExposure::Controller do
           expose :thing
           expect(request).to receive(:get?).and_return(true)
           expect(controller).not_to receive(:thing_params)
-          expect(Thing).to receive(:new).and_return(thing)
-          expect(thing).to receive(:attributes=).with({})
+          expect(Thing).to receive(:new).with({}).and_return(thing)
         end
 
         it "uses params method on non-get request" do
           expose :thing
           expect(request).to receive(:get?).and_return(false)
-          expect(Thing).to receive(:new).and_return(thing)
-          expect(thing).to receive(:attributes=).with(foo: :bar)
+          expect(Thing).to receive(:new).with(foo: :bar).and_return(thing)
           expect(controller).to receive(:thing_params).and_return(foo: :bar)
         end
 
         it "can use custom params method name" do
           expose :thing, build_params: :custom_params_method_name
           expect(request).to receive(:get?).and_return(false)
-          expect(Thing).to receive(:new).and_return(thing)
-          expect(thing).to receive(:attributes=).with(foo: :bar)
+          expect(Thing).to receive(:new).with(foo: :bar).and_return(thing)
           expect(controller).to receive(:custom_params_method_name).and_return(foo: :bar)
         end
 
         it "can use custom build params" do
           expose :thing, build_params: ->{ foobar }
           expect(controller).to receive(:foobar).and_return(42)
-          expect(Thing).to receive(:new).and_return(thing)
-          expect(thing).to receive(:attributes=).with(42)
+          expect(Thing).to receive(:new).with(42).and_return(thing)
         end
       end
     end
@@ -265,7 +260,6 @@ RSpec.describe DecentExposure::Controller do
     context "build/find" do
       let(:current_user){ double("User") }
       let(:scope){ double("Scope") }
-      let(:thing){ double("Thing") }
 
       before do
         expect(controller).to receive(:current_user).and_return(current_user)
@@ -273,27 +267,22 @@ RSpec.describe DecentExposure::Controller do
         expose :thing, parent: :current_user
       end
 
-      after{ expect(controller.thing).to eq(thing) }
+      after{ expect(controller.thing).to eq(42) }
 
       it "sets the scope to belong to parent defined by controller method" do
-        expect(scope).to receive(:new).and_return(thing)
-        expect(thing).to receive(:attributes=).with({})
+        expect(scope).to receive(:new).with({}).and_return(42)
       end
 
       it "scopes the find to proper scope" do
         controller.params.merge! thing_id: 10
-        expect(scope).to receive(:find).with(10).and_return(thing)
+        expect(scope).to receive(:find).with(10).and_return(42)
       end
     end
   end
 
   context "override model" do
     let(:different_thing){ double("DifferentThing") }
-
-    before do
-      expect(DifferentThing).to receive(:new).and_return(different_thing)
-      expect(different_thing).to receive(:attributes=).with({})
-    end
+    before{ expect(DifferentThing).to receive(:new).with({}).and_return(different_thing) }
 
     after{ expect(controller.thing).to eq(different_thing) }
 
@@ -317,21 +306,17 @@ RSpec.describe DecentExposure::Controller do
   context "override scope" do
     it "allows overriding scope with proc" do
       scope = double("Scope")
-      thing = double("Thing")
       expose :thing, scope: ->{ scope }
-      expect(scope).to receive(:new).and_return(thing)
-      expect(thing).to receive(:attributes=).with({})
-      expect(controller.thing).to eq(thing)
+      expect(scope).to receive(:new).and_return(42)
+      expect(controller.thing).to eq(42)
     end
 
     it "allows overriding model scope using symbol" do
       scope = double("Scope")
-      thing = double("Thing")
       expect(Thing).to receive(:custom_scope).and_return(scope)
-      expect(scope).to receive(:new).and_return(thing)
-      expect(thing).to receive(:attributes=).with({})
+      expect(scope).to receive(:new).and_return(42)
       expose :thing, scope: :custom_scope
-      expect(controller.thing).to eq(thing)
+      expect(controller.thing).to eq(42)
     end
   end
 
@@ -361,8 +346,7 @@ RSpec.describe DecentExposure::Controller do
     it "allows specify decorator" do
       expose :thing, decorate: ->(thing){ decorate(thing) }
       thing = double("Thing")
-      expect(Thing).to receive(:new).and_return(thing)
-      expect(thing).to receive(:attributes=).with({})
+      expect(Thing).to receive(:new).with({}).and_return(thing)
       expect(controller).to receive(:decorate).with(thing)
       controller.thing
     end

--- a/spec/features/birds_controller_spec.rb
+++ b/spec/features/birds_controller_spec.rb
@@ -67,4 +67,20 @@ RSpec.describe BirdsController, type: :controller do
       expect(controller.bird?).to be true
     end
   end
+
+  context "when egg depends on bird being linked" do
+    class BirdsController
+      expose :bird
+      expose :egg, parent: :bird
+
+      def egg_params
+        params.require(:egg).permit(:name)
+      end
+    end
+
+    it "builds egg through bird with a name that depends on bird's species" do
+      post :create, request_params(bird: { name: 'Bob' }, egg: { name: 'Bill' })
+      expect(controller.egg.name).to eq("Bill (Kiwi)")
+    end
+  end
 end

--- a/spec/features/birds_controller_spec.rb
+++ b/spec/features/birds_controller_spec.rb
@@ -84,3 +84,20 @@ RSpec.describe BirdsController, type: :controller do
     end
   end
 end
+
+RSpec.describe EggsController, type: :controller do
+  context "when egg is loaded standalone" do
+    class EggsController
+      expose :egg
+
+      def egg_params
+        params.require(:egg).permit(:name)
+      end
+    end
+
+    it "builds egg with name that includes default type" do
+      post :create, request_params(egg: { name: 'Barry' })
+      expect(controller.egg.name).to eq("Barry (Fantail)")
+    end
+  end
+end

--- a/spec/support/rails_app.rb
+++ b/spec/support/rails_app.rb
@@ -14,6 +14,7 @@ module Rails
       @routes ||= ActionDispatch::Routing::RouteSet.new.tap do |routes|
         routes.draw do
           resources :birds
+          resources :eggs
 
           namespace :api do
             resources :birds
@@ -32,10 +33,18 @@ module Rails
   end
 end
 
+module ActiveRecord
+  class Relation
+  end
+
+  class Base
+  end
+end
+
 class Bird
   attr_accessor :name
 
-  def attributes=(options)
+  def initialize(options = {})
     options.each { |k, v| self.public_send("#{k}=", v) }
   end
 
@@ -48,7 +57,7 @@ class Bird
   end
 end
 
-class EggsRelation
+class EggsRelation < ActiveRecord::Relation
   def initialize(bird)
     @bird = bird
   end
@@ -61,7 +70,7 @@ class EggsRelation
   end
 end
 
-class Egg
+class Egg < ActiveRecord::Base
   attr_reader :name
   attr_accessor :bird
   delegate :species, to: :bird
@@ -71,7 +80,7 @@ class Egg
   end
 
   def name=(value)
-    @name = "#{value} (#{species})"
+    @name = "#{value} (#{bird ? species : 'Fantail'})"
   end
 end
 
@@ -89,6 +98,12 @@ class BirdsController < ApplicationController
     define_method action do
       head :ok
     end
+  end
+end
+
+class EggsController < ApplicationController
+  define_method 'create' do
+    head :ok
   end
 end
 

--- a/spec/support/rails_app.rb
+++ b/spec/support/rails_app.rb
@@ -34,8 +34,44 @@ end
 
 class Bird
   attr_accessor :name
-  def initialize(options = {})
+
+  def attributes=(options)
     options.each { |k, v| self.public_send("#{k}=", v) }
+  end
+
+  def species
+    'Kiwi'
+  end
+
+  def eggs
+    EggsRelation.new(self)
+  end
+end
+
+class EggsRelation
+  def initialize(bird)
+    @bird = bird
+  end
+
+  def new
+    egg = Egg.new
+    egg.bird = @bird
+
+    egg
+  end
+end
+
+class Egg
+  attr_reader :name
+  attr_accessor :bird
+  delegate :species, to: :bird
+
+  def attributes=(options)
+    options.each { |k, v| self.public_send("#{k}=", v) }
+  end
+
+  def name=(value)
+    @name = "#{value} (#{species})"
   end
 end
 


### PR DESCRIPTION
First creating the instance, then applying the parameters allows us to work around a quirk in `active_record` where the relations aren't established on the object until after the parameters are applied. This means if any of our attribute setters reference the relation, they will fail if we don't seperate these steps.

Points to consider:
- The `attributes` method may not exist on non-active_record exposures. Are we assuming too much?
- In your feature spec file, the `BirdsController` isn't thrown away between each test, so redefining something like `expose :bird` can break other tests in a non-deterministic way (due to test ordering). It hasn't been exposed yet because you don't redefine any exposures in your tests, but just wanted to give a heads-up as I ran into this when trying to redefine `:bird`. A seperate controller class per test would probably work best to avoid this problem.
- I had to adjust a lot of controller tests to cope with the new expectation that we'll always call `new` without arguments, and then subsequently call `attributes=`.

Fixes #191