### PR TITLE
Override build params for HEAD requests

### DIFF
--- a/lib/decent_exposure/flow.rb
+++ b/lib/decent_exposure/flow.rb
@@ -42,7 +42,7 @@ module DecentExposure
     delegate :params, to: :controller
 
     def get_request?
-      controller.request.get?
+      controller.request.get? || controller.request.head?
     end
 
     def params_method_name

--- a/spec/decent_exposure/controller_spec.rb
+++ b/spec/decent_exposure/controller_spec.rb
@@ -190,14 +190,14 @@ RSpec.describe DecentExposure::Controller do
 
         it "uses params method on non-get request" do
           expose :thing
-          expect(request).to receive(:get?).and_return(false)
+          expect(request).to receive_messages(get?: false, head?: false)
           expect(Thing).to receive(:new).with(foo: :bar).and_return(thing)
           expect(controller).to receive(:thing_params).and_return(foo: :bar)
         end
 
         it "can use custom params method name" do
           expose :thing, build_params: :custom_params_method_name
-          expect(request).to receive(:get?).and_return(false)
+          expect(request).to receive_messages(get?: false, head?: false)
           expect(Thing).to receive(:new).with(foo: :bar).and_return(thing)
           expect(controller).to receive(:custom_params_method_name).and_return(foo: :bar)
         end

--- a/spec/features/birds_controller_spec.rb
+++ b/spec/features/birds_controller_spec.rb
@@ -38,6 +38,13 @@ RSpec.describe BirdsController, type: :controller do
       get :new
       expect(controller.bird).to be_a(Bird)
     end
+
+    context "when request.method is HEAD" do
+      it "builds bird if id is not provided" do
+        head :new
+        expect(controller.bird).to be_a(Bird)
+      end
+    end
   end
 
   context "when bird_params is defined" do


### PR DESCRIPTION
Hi everyone.

```ruby
class ThingsController < ApplicationController
  expose :thing

  def new
    thing.author = 'John Doe'
  end

  private

  def thing_params
    params.require(:thing).permit(:foo, :bar)
  end
end
```

When exposed object is called in controller action and somebody sends `HEAD` request instead of `GET` it raises error: 

> ActionController::ParameterMissing (param is missing or the value is empty: thing):

because [DecentExposure::Behavior#build_params](https://github.com/hashrocket/decent_exposure/blob/master/lib/decent_exposure/behavior.rb#L78) returns empty hash only for `GET` requests. 

It doesn't look like a big problem but anyway it's a bit annoying. Can we change this logic?

Thx