### PR TITLE
Fixes a Ruby 27 warning

### DIFF
--- a/lib/decent_exposure/controller.rb
+++ b/lib/decent_exposure/controller.rb
@@ -17,8 +17,8 @@ module DecentExposure
       #
       # Returns the helper methods that are now defined on the class
       # where this method is included.
-      def expose(*args, &block)
-        Exposure.expose! self, *args, &block
+      def expose(*args, **options, &block)
+        Exposure.expose! self, *args, **options, &block
       end
 
       # Public: Exposes an attribute to a controller Class.
@@ -33,8 +33,8 @@ module DecentExposure
       #
       # Sets the exposed attribute to a before_action callback in the
       # controller.
-      def expose!(name, *args, &block)
-        expose name, *args, &block
+      def expose!(name, *args, **options, &block)
+        expose name, *args, **options, &block
         before_action name
       end
 

--- a/lib/decent_exposure/exposure.rb
+++ b/lib/decent_exposure/exposure.rb
@@ -13,8 +13,8 @@ module DecentExposure
     #          the Proc when called.
     #
     # Returns a collection of exposed helper methods.
-    def self.expose!(*args, &block)
-      new(*args, &block).expose!
+    def self.expose!(*args, **options, &block)
+      new(*args, **options, &block).expose!
     end
 
     # Public: Initalize an Exposure with a hash of options.

--- a/spec/decent_exposure/controller_spec.rb
+++ b/spec/decent_exposure/controller_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe DecentExposure::Controller do
   before { allow(controller).to receive(:request) { request } }
 
   %w[expose expose! exposure_config].each do |method_name|
-    define_method method_name do |*args, &block|
-      controller_klass.send method_name, *args, &block
+    define_method method_name do |*args, **options, &block|
+      controller_klass.send method_name, *args, **options, &block
     end
   end
 

--- a/spec/features/api_birds_controller_spec.rb
+++ b/spec/features/api_birds_controller_spec.rb
@@ -24,13 +24,13 @@ RSpec.describe Api::BirdsController, type: :controller do
 
     it "finds model by id" do
       expect(Bird).to receive(:find).with("bird-id").and_return(bird)
-      get :show, request_params(id: "bird-id")
+      get :show, **request_params(id: "bird-id")
       expect(controller.bird).to eq(bird)
     end
 
     it "finds model by bird_id" do
       expect(Bird).to receive(:find).with("bird-id").and_return(bird)
-      get :new, request_params(bird_id: "bird-id")
+      get :new, **request_params(bird_id: "bird-id")
       expect(controller.bird).to eq(bird)
     end
 
@@ -50,7 +50,7 @@ RSpec.describe Api::BirdsController, type: :controller do
     end
 
     it "bird is build with params set" do
-      post :create, request_params(bird: {name: "crow"})
+      post :create, **request_params(bird: {name: "crow"})
       expect(controller.bird.name).to eq("crow")
     end
   end
@@ -63,7 +63,7 @@ RSpec.describe Api::BirdsController, type: :controller do
 
     it "exposes bird?" do
       expect(Bird).to receive(:find).with("bird-id").and_return(bird)
-      get :show, request_params(id: "bird-id")
+      get :show, **request_params(id: "bird-id")
       expect(controller.bird?).to be true
     end
   end

--- a/spec/features/birds_controller_spec.rb
+++ b/spec/features/birds_controller_spec.rb
@@ -24,13 +24,13 @@ RSpec.describe BirdsController, type: :controller do
 
     it "finds model by id" do
       expect(Bird).to receive(:find).with("bird-id").and_return(bird)
-      get :show, request_params(id: "bird-id")
+      get :show, **request_params(id: "bird-id")
       expect(controller.bird).to eq(bird)
     end
 
     it "finds model by bird_id" do
       expect(Bird).to receive(:find).with("bird-id").and_return(bird)
-      get :new, request_params(bird_id: "bird-id")
+      get :new, **request_params(bird_id: "bird-id")
       expect(controller.bird).to eq(bird)
     end
 
@@ -50,7 +50,7 @@ RSpec.describe BirdsController, type: :controller do
     end
 
     it "bird is build with params set" do
-      post :create, request_params(bird: {name: "crow"})
+      post :create, **request_params(bird: {name: "crow"})
       expect(controller.bird.name).to eq("crow")
     end
   end
@@ -63,7 +63,7 @@ RSpec.describe BirdsController, type: :controller do
 
     it "exposes bird?" do
       expect(Bird).to receive(:find).with("bird-id").and_return(bird)
-      get :show, request_params(id: "bird-id")
+      get :show, **request_params(id: "bird-id")
       expect(controller.bird?).to be true
     end
   end


### PR DESCRIPTION
Fixes the warning
> warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call