### PR TITLE
Ruby 3.0 support

### DIFF
--- a/decent_exposure.gemspec
+++ b/decent_exposure.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.test_files = spec.files.grep(/\Aspec\//)
   spec.require_path = "lib"
 
-  spec.required_ruby_version = "~> 2.0"
+  spec.required_ruby_version = ">= 2.0"
 
   spec.add_dependency "activesupport", ">= 4.0"
   spec.add_development_dependency "railties", ">= 4.0"

--- a/lib/decent_exposure/controller.rb
+++ b/lib/decent_exposure/controller.rb
@@ -17,8 +17,8 @@ module DecentExposure
       #
       # Returns the helper methods that are now defined on the class
       # where this method is included.
-      def expose(*args, &block)
-        Exposure.expose! self, *args, &block
+      def expose(*args, **options, &block)
+        Exposure.expose! self, *args, **options, &block
       end
 
       # Public: Exposes an attribute to a controller Class.
@@ -33,8 +33,8 @@ module DecentExposure
       #
       # Sets the exposed attribute to a before_action callback in the
       # controller.
-      def expose!(name, *args, &block)
-        expose name, *args, &block
+      def expose!(name, *args, **options, &block)
+        expose name, *args, **options, &block
         before_action name
       end
 

--- a/lib/decent_exposure/exposure.rb
+++ b/lib/decent_exposure/exposure.rb
@@ -13,8 +13,8 @@ module DecentExposure
     #          the Proc when called.
     #
     # Returns a collection of exposed helper methods.
-    def self.expose!(*args, &block)
-      new(*args, &block).expose!
+    def self.expose!(*args, **options, &block)
+      new(*args, **options, &block).expose!
     end
 
     # Public: Initalize an Exposure with a hash of options.

--- a/spec/decent_exposure/controller_spec.rb
+++ b/spec/decent_exposure/controller_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe DecentExposure::Controller do
   before { allow(controller).to receive(:request) { request } }
 
   %w[expose expose! exposure_config].each do |method_name|
-    define_method method_name do |*args, &block|
-      controller_klass.send method_name, *args, &block
+    define_method method_name do |*args, **options, &block|
+      controller_klass.send method_name, *args, **options, &block
     end
   end
 

--- a/spec/features/api_birds_controller_spec.rb
+++ b/spec/features/api_birds_controller_spec.rb
@@ -24,13 +24,13 @@ RSpec.describe Api::BirdsController, type: :controller do
 
     it "finds model by id" do
       expect(Bird).to receive(:find).with("bird-id").and_return(bird)
-      get :show, request_params(id: "bird-id")
+      get :show, **request_params(id: "bird-id")
       expect(controller.bird).to eq(bird)
     end
 
     it "finds model by bird_id" do
       expect(Bird).to receive(:find).with("bird-id").and_return(bird)
-      get :new, request_params(bird_id: "bird-id")
+      get :new, **request_params(bird_id: "bird-id")
       expect(controller.bird).to eq(bird)
     end
 
@@ -50,7 +50,7 @@ RSpec.describe Api::BirdsController, type: :controller do
     end
 
     it "bird is build with params set" do
-      post :create, request_params(bird: {name: "crow"})
+      post :create, **request_params(bird: {name: "crow"})
       expect(controller.bird.name).to eq("crow")
     end
   end
@@ -63,7 +63,7 @@ RSpec.describe Api::BirdsController, type: :controller do
 
     it "exposes bird?" do
       expect(Bird).to receive(:find).with("bird-id").and_return(bird)
-      get :show, request_params(id: "bird-id")
+      get :show, **request_params(id: "bird-id")
       expect(controller.bird?).to be true
     end
   end

--- a/spec/features/birds_controller_spec.rb
+++ b/spec/features/birds_controller_spec.rb
@@ -24,13 +24,13 @@ RSpec.describe BirdsController, type: :controller do
 
     it "finds model by id" do
       expect(Bird).to receive(:find).with("bird-id").and_return(bird)
-      get :show, request_params(id: "bird-id")
+      get :show, **request_params(id: "bird-id")
       expect(controller.bird).to eq(bird)
     end
 
     it "finds model by bird_id" do
       expect(Bird).to receive(:find).with("bird-id").and_return(bird)
-      get :new, request_params(bird_id: "bird-id")
+      get :new, **request_params(bird_id: "bird-id")
       expect(controller.bird).to eq(bird)
     end
 
@@ -50,7 +50,7 @@ RSpec.describe BirdsController, type: :controller do
     end
 
     it "bird is build with params set" do
-      post :create, request_params(bird: {name: "crow"})
+      post :create, **request_params(bird: {name: "crow"})
       expect(controller.bird.name).to eq("crow")
     end
   end
@@ -63,7 +63,7 @@ RSpec.describe BirdsController, type: :controller do
 
     it "exposes bird?" do
       expect(Bird).to receive(:find).with("bird-id").and_return(bird)
-      get :show, request_params(id: "bird-id")
+      get :show, **request_params(id: "bird-id")
       expect(controller.bird?).to be true
     end
   end


### PR DESCRIPTION
I'm just extending on @marcrohloff's work and relaxing the Ruby version requirement - so you'll definitely want to merge in #195 first. The build for this PR passes locally when I use Ruby v3.0.0.

I'm happy to submit another PR that extends the tested Ruby/Rails versions to cover more modern releases - but also, wondering if there's a preference to change CI systems given Travis is no longer supporting free OSS builds. I've been moving my own projects over to both CircleCI and Github Actions (depending on project requirements), so I'm happy to put together a configuration for either if that's desired.