### PR TITLE
feat(loader): enable lazy loading on specific actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ end
 
 The exposure is also lazy, which means that it won't do anything until you call
 the method. To eliminate this laziness you can use the `expose!` macro instead,
-which will try to resolve the exposure in a before filter.
+which will try to resolve the exposure in a before filter. You can also use
+`before_action :load_thing, only: :sort` to lazy load only on specific actions.
 
 It is possible to override each step with options. The acceptable options to the
 `expose` macro are:

--- a/lib/decent_exposure/attribute.rb
+++ b/lib/decent_exposure/attribute.rb
@@ -32,6 +32,13 @@ module DecentExposure
       "#{name}=".to_sym
     end
 
+    # Public: The loader method for the Attribute.
+    #
+    # Returns the method name for loading the Attribute.
+    def loader_method_name
+      "load_#{name}".to_sym
+    end
+
     # Public: Expose a getter and setter method for the Attribute
     # on the passed in Controller class.
     #
@@ -47,6 +54,10 @@ module DecentExposure
 
         define_method attribute.setter_method_name do |value|
           Context.new(self, attribute).set(value)
+        end
+
+        define_method attribute.loader_method_name do
+          Context.new(self, attribute).load
         end
       end
     end

--- a/lib/decent_exposure/context.rb
+++ b/lib/decent_exposure/context.rb
@@ -33,6 +33,14 @@ module DecentExposure
       ivar_set(value)
     end
 
+    # Public: Load a record or collection.
+    #
+    # This method will simply call get and lazy load in case in returns an
+    # collection.
+    def load
+      get.tap { |value| value.load if value.respond_to?(:load) }
+    end
+
     private
 
     delegate :instance_variable_set, :instance_variable_get,

--- a/spec/decent_exposure/controller_spec.rb
+++ b/spec/decent_exposure/controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe DecentExposure::Controller do
     end
   end
 
-  context "getter/setter methods" do
+  context "getter/setter/loader methods" do
     before { expose :thing }
 
     it "defines getter method" do
@@ -38,6 +38,10 @@ RSpec.describe DecentExposure::Controller do
 
     it "defines setter method" do
       expect(controller).to respond_to(:thing=).with(1).argument
+    end
+
+    it "defines loader method" do
+      expect(controller).to respond_to(:load_thing)
     end
   end
 


### PR DESCRIPTION
One of the drawbacks of `expose!` is that it run on every controller action. The idea behind this pull request is to allow developers to eliminate lazy loadiness on specific actions without the weirdness of `before_action :thing, except: :sort`. So, instead you can use `before_action :load_thing, except: :sort`. More clarity and better naming conventions. It will also really eliminate lazy load for ActiveRecord collections by calling `load` before. 