### PR TITLE
Bugfix: ActionMailers with keyword args fail in Ruby 3.2.1

### DIFF
--- a/lib/decent_exposure/mailer.rb
+++ b/lib/decent_exposure/mailer.rb
@@ -9,6 +9,7 @@ module DecentExposure
           self.params = arg.stringify_keys if arg && Hash === arg
           super
         end
+        ruby2_keywords(:process_action) if respond_to?(:ruby2_keywords, true)
       end
     end
   end


### PR DESCRIPTION
This fixes an issue where mailer methods defined with keyword args like `def test(user, notes:)` fail with Ruby 3.2.1 and Rails 7.0.4
