### PR TITLE
Allow for namespaced models.

### DIFF
--- a/lib/decent_exposure/behavior.rb
+++ b/lib/decent_exposure/behavior.rb
@@ -41,7 +41,7 @@ module DecentExposure
     #
     # Returns a standard Class name.
     def model
-      name.to_s.classify.constantize
+      [model_namespace, name.to_s.classify].compact.join('::').constantize
     end
 
     # Public: Find an object on the supplied scope.
@@ -84,6 +84,10 @@ module DecentExposure
     end
 
     protected
+    def model_namespace
+      options[:model_namespace].to_s
+    end
+
 
     def params_id_key_candidates
       ["#{model_param_key}_id", "#{name}_id", "id"].uniq

--- a/lib/decent_exposure/exposure.rb
+++ b/lib/decent_exposure/exposure.rb
@@ -82,6 +82,7 @@ module DecentExposure
       normalize_parent_option
       normalize_from_option
       normalize_find_by_option
+      normalize_model_namespace_option
     end
 
     def normalize_fetch_option
@@ -135,6 +136,12 @@ module DecentExposure
         end
 
         -> { model }
+      end
+    end
+
+    def normalize_model_namespace_option
+      normalize_non_proc_option :model_namespace do |value|
+        -> { value.to_s }
       end
     end
 

--- a/lib/decent_exposure/version.rb
+++ b/lib/decent_exposure/version.rb
@@ -1,3 +1,3 @@
 module DecentExposure
-  VERSION = "3.0.4"
+  VERSION = "3.0.5"
 end


### PR DESCRIPTION
Our use case allows for models to be namespaced as we're taking advantage of Rails Multi-Database access.  As a result, each database models are namespaced; e.g., `DB1::Tenant`.  We also want to be able to use the `parent` or `scope` option when we access sub-associations.  e.g., `DB1::Tenant.has_many :certificates`, hence:

```
expose :tenant, model_namespace: :DB1
expose :certificate, parent: :tenant, model_namespace: :DB1
```
This translates to:
```
def tenant = DB1::Tenant.find_or_initialize_by(id: params[:id])
def certificate = tenant.certificates.find_or_initialize_by(id: params[:id])
```
